### PR TITLE
fix for #43

### DIFF
--- a/bin/klaus
+++ b/bin/klaus
@@ -4,6 +4,7 @@
 import sys
 import os
 import argparse
+import locale
 
 from dulwich.errors import NotGitRepository
 from dulwich.repo import Repo
@@ -53,7 +54,7 @@ def main():
         args.site_name = '%s:%d' % (args.host, args.port)
 
     app = klaus.make_app(args.repos,
-                         args.site_name or args.host,
+                         args.site_name.decode(locale.getpreferredencoding() or 'utf-8'),
                          args.smarthttp,
                          args.htdigest)
 


### PR DESCRIPTION
decode --site-name argument with system's preferred encoding or fallback to utf-8, #43 
