### PR TITLE
Add TOC support in markdown parser.

### DIFF
--- a/klaus/markup.py
+++ b/klaus/markup.py
@@ -8,7 +8,7 @@ try:
     def render_markdown(content):
         return markdown.markdown(content, extensions=['toc'])
         
-    LANGUAGES.append((['.md', '.mkdn'], render.markdown))
+    LANGUAGES.append((['.md', '.mkdn'], render_markdown))
 except ImportError:
     pass
 


### PR DESCRIPTION
Enable toc extension in markdown.
