### PR TITLE
Add .markdown as possible extension

### DIFF
--- a/klaus/markup.py
+++ b/klaus/markup.py
@@ -30,7 +30,7 @@ def _load_markdown():
     def render_markdown(content):
         return markdown.markdown(content, extensions=['toc', 'extra'])
 
-    LANGUAGES.append((['.md', '.mkdn'], render_markdown))
+    LANGUAGES.append((['.md', '.mkdn', '.markdown'], render_markdown))
 
 
 def _load_restructured_text():
@@ -41,14 +41,14 @@ def _load_restructured_text():
         return
 
     def render_rest(content):
-        # start by h2 and ignore invalid directives and so on (most likely from Sphinx)
+        # start by h2 and ignore invalid directives and so on
+        # (most likely from Sphinx)
         settings = {'initial_header_level': 2, 'report_level': 'quiet'}
         return publish_parts(content,
-                            writer=Writer(),
-                            settings_overrides=settings).get('html_body')
+                             writer=Writer(),
+                             settings_overrides=settings).get('html_body')
 
     LANGUAGES.append((['.rst', '.rest'], render_rest))
-
 
 
 for loader in [_load_markdown, _load_restructured_text]:


### PR DESCRIPTION
.markdown as another possible extensions for markdown-files

Doing some PEP8-cleanup in markup.py
