### PR TITLE
handle refs with / properly, fixes #36

### DIFF
--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -48,13 +48,13 @@ class Klaus(flask.Flask):
         for endpoint, rule in [
             ('repo_list',   '/'),
             ('blob',        '/<repo>/blob/'),
-            ('blob',        '/<repo>/blob/<path:rev>/<path:path>'),
+            ('blob',        '/<repo>/blob/<rev>/<path:path>'),
             ('raw',         '/<repo>/raw/<path:path>'),
-            ('raw',         '/<repo>/raw/<path:rev>/<path:path>'),
+            ('raw',         '/<repo>/raw/<rev>/<path:path>'),
             ('commit',      '/<repo>/commit/<path:rev>'),
             ('history',     '/<repo>/'),
-            ('history',     '/<repo>/tree/<path:rev>'),
-            ('history',     '/<repo>/tree/<path:rev>/<path:path>'),
+            ('history',     '/<repo>/tree/<rev>'),
+            ('history',     '/<repo>/tree/<rev>/<path:path>'),
             ('download',    '/<repo>/tarball/<path:rev>'),
             ('robots_txt',  '/robots.txt/'),
         ]:

--- a/klaus/utils.py
+++ b/klaus/utils.py
@@ -199,3 +199,9 @@ def guess_git_revision():
             ['git', 'log', '--format=%h', '-n', '1'],
             cwd=git_dir
         ).strip()
+
+
+def sanitize_branch_name(name, chars='./', repl='-'):
+    for char in chars:
+        name = name.replace(char, repl)
+    return name


### PR DESCRIPTION
With this patch, Klaus handles git refs with a slash '/', e.g. feature/foo correctly. The URL structure remains the same, but there is no longer a difference in `<rev>` and `<path>`.

Any URL is bit by bit checked if it contains a valid ref:

```
-> /klaus/tree/foo/bar/setup.py
<- foo/bar/setup.py (no)
<- foo/bar, setup.py (yes, foo/bar is a valid ref)
```

For URL reconstruction, url_for(view, ...), there are still `rev` and `path` arguments. The view on the other hand, joins both parts to a single URL (and splits them (again) into rev and path).

Tarball filenames for branches containing a slash are substituted with a hyphen, so project@foo/bar becomes project@foo-bar.tar.gz
