### PR TITLE
catch WindowsError

### DIFF
--- a/klaus/utils.py
+++ b/klaus/utils.py
@@ -195,7 +195,10 @@ except ImportError:
 def guess_git_revision():
     git_dir = os.path.join(os.path.dirname(__file__), '..', '.git')
     if os.path.exists(git_dir):
-        return check_output(
-            ['git', 'log', '--format=%h', '-n', '1'],
-            cwd=git_dir
-        ).strip()
+        try:
+            return check_output(
+                ['git', 'log', '--format=%h', '-n', '1'],
+                cwd=git_dir
+            ).strip()
+        except WindowsError:
+            return None


### PR DESCRIPTION
When running klaus on windows the `guess_git_revision` method will throw a `WindowsException` because the git executable cannot be found. This error even occurs when the git bin directory has been added to the PATH variable.
