### PR TITLE
add option to auto-launch browser on server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 0.4.9 (TBA)
 -----------
 * Bug #104: "git" executable unnecessarily required to be available (@Mechazawa)
+* Add option to auto-launch a web-browser on startup (@rjw57)
 
 0.4.8 (June 22, 2014)
 ---------------------

--- a/bin/klaus
+++ b/bin/klaus
@@ -4,6 +4,7 @@
 import sys
 import os
 import argparse
+from webbrowser import open as open_url
 
 from dulwich.errors import NotGitRepository
 from dulwich.repo import Repo
@@ -28,6 +29,8 @@ def make_parser():
     parser.add_argument('--host',     help="default: 127.0.0.1", default='127.0.0.1')
     parser.add_argument('--port',     help="default: 8080", default=8080, type=int)
     parser.add_argument('--site-name', help="site name showed in header. default: your hostname")
+    parser.add_argument('-b', '--browser', help="launch a browser on server start",
+                        action='store_true', default=False)
 
     parser.add_argument('repos', help='repositories to serve',
                         metavar='DIR', nargs='*', type=git_repository)
@@ -60,6 +63,14 @@ def main():
         args.htdigest
     )
 
+    if args.browser:
+        # Open a web browser onto the server URL. Technically we're jumping the
+        # gun a little here since the server is not running but there's not a
+        # clean way to run a function after the server has started without
+        # losing the simplicity of the code. In the Real World (TM) it'll take
+        # longer for the browser to start than it will for use to start
+        # serving.
+        open_url('http://%s:%s' % (args.host, args.port))
     app.run(args.host, args.port, args.debug)
 
 


### PR DESCRIPTION
Add command-line argument --browser (shortened to -b) which will
auto-launch a web-browser pointing to the Klaus server via the Python
webbrowser module.

Note that we do things in the wrong order in that we launch the browser
and *then* start the server. In the absence of a cleaner way of getting
a function to run after server setup this approach actually works in
practice. If this doesn't Just Work for someone we can think again about
more complex options.