### PR TITLE
split browser option into flag and option

### DIFF
--- a/bin/klaus
+++ b/bin/klaus
@@ -29,8 +29,10 @@ def make_parser():
     parser.add_argument('--host',     help="default: 127.0.0.1", default='127.0.0.1')
     parser.add_argument('--port',     help="default: 8080", default=8080, type=int)
     parser.add_argument('--site-name', help="site name showed in header. default: your hostname")
-    parser.add_argument('-b', '--browser', help="open klaus in default browser on server start. Optional argument: browser executable to use",
-                        default=None, const='__default_browser__', nargs='?')
+    parser.add_argument('-b', '--browser', help="open klaus in a browser on server start",
+                        default=False, action='store_true')
+    parser.add_argument('-B', '--with-browser', help="specify which browser to use with --browser",
+                        metavar='BROWSER', default=None)
 
     parser.add_argument('repos', help='repositories to serve',
                         metavar='DIR', nargs='*', type=git_repository)
@@ -75,10 +77,10 @@ def _open_browser(args):
     # losing the simplicity of the code. In the Real World (TM) it'll take
     # longer for the browser to start than it will for us to start
     # serving, so we'll be OK.
-    if args.browser == '__default_browser__':
+    if args.with_browser is None:
         opener = webbrowser.open
     else:
-        opener = webbrowser.get(args.browser).open
+        opener = webbrowser.get(args.with_browser).open
     opener('http://%s:%s' % (args.host, args.port))
 
 


### PR DESCRIPTION
As noted in #108, the ``--browser`` option is currently broken if no
argument is supplied. Split the argument into two: a flag
(``--browser``) indicating if a browser is to be opened and an option
(``--with-browser``) which may optionally be used to specify which
browser is to be used.

Fixes #108.