### PR TITLE
default to current directory as repo if none specified

### DIFF
--- a/bin/klaus
+++ b/bin/klaus
@@ -32,7 +32,7 @@ def make_parser():
     parser.add_argument('-b', '--browser', help="open klaus in default browser on server start. Optional argument: browser executable to use",
                         default=None, const='__default_browser__', nargs='?')
 
-    parser.add_argument('repos', help='repositories to serve',
+    parser.add_argument('repos', help='repositories to serve or, if omitted, use current directory',
                         metavar='DIR', nargs='*', type=git_repository)
 
     grp = parser.add_argument_group("Git Smart HTTP")
@@ -51,7 +51,8 @@ def main():
     args = make_parser().parse_args()
 
     if not args.repos:
-        print >> sys.stderr, "WARNING: No repositories supplied -- syntax is 'klaus dir1 dir2...'."
+        print >> sys.stderr, "WARNING: No repositories supplied -- using current directory as default"
+        args.repos = [os.getcwd()]
 
     if not args.site_name:
         args.site_name = '%s:%d' % (args.host, args.port)


### PR DESCRIPTION
This is a pure laziness PR :). It's nice when cloning a new repo to poke around. Currently, the quickest way to pop up a klaus view of a repo you're already in is:

```console
$ klaus -b .
```

This PR adds a single commit which just changes the (currently unassigned) "no repos specified" behaviour to use the current working directory. My use case for this is extremely lazy: I don't want to type "space" and ".". It does follow the usual git "implicitly this repo" rules though.

Note: no attempt is made to determine the repo root. Running this from somewhere deep in the repo won't work. It could be made to work but it's probably overkill.