### PR TITLE
Added a wsgi application that automatically discovers all git repositori...

### DIFF
--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -16,7 +16,7 @@ class Klaus(flask.Flask):
     }
 
     def __init__(self, repo_paths, site_name, use_smarthttp, **kwargs):
-        self.repo_map = dict((repo.path, repo) for repo in map(FancyRepo, repo_paths))
+        self.repo_map = dict((path, FancyRepo(path)) for path in repo_paths)
         self.site_name = site_name
         self.use_smarthttp = use_smarthttp
 

--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -17,13 +17,16 @@ class Klaus(flask.Flask):
 
     def __init__(self, repo_paths, site_name, use_smarthttp):
         self.repos = map(FancyRepo, repo_paths)
-        self.repo_map = dict((repo.name, repo) for repo in self.repos)
+        self.update_repos_list()
         self.site_name = site_name
         self.use_smarthttp = use_smarthttp
 
         flask.Flask.__init__(self, __name__)
 
         self.setup_routes()
+
+    def update_repos_list(self):
+        self.repo_map = dict((repo.name, repo) for repo in self.repos)
 
     def create_jinja_environment(self):
         """ Called by Flask.__init__ """
@@ -61,12 +64,12 @@ class Klaus(flask.Flask):
             self.add_url_rule(rule, view_func=getattr(views, endpoint))
 
 
-def make_app(repos, site_name, use_smarthttp=False, htdigest_file=None):
+def make_app(repos, site_name, use_smarthttp=False, htdigest_file=None, klass=Klaus):
     """
     Returns a WSGI app with all the features (smarthttp, authentication)
     already patched in.
     """
-    app = Klaus(
+    app = klass(
         repos,
         site_name,
         use_smarthttp,

--- a/klaus/contrib/autodiscover.py
+++ b/klaus/contrib/autodiscover.py
@@ -1,7 +1,6 @@
 import os
 import dulwich
 import logging
-import functools
 
 from klaus.repo import FancyRepo
 from klaus import Klaus, make_app
@@ -12,7 +11,6 @@ try:
         FileSystemEventHandler,
         DirCreatedEvent,
         DirDeletedEvent,
-        DirMovedEvent
     )
 except ImportError:
     import sys
@@ -119,7 +117,7 @@ class KlausAutoDiscover(Klaus):
     """
     Instead of the normal Klaus behaviour of receiving a list of git repositories
     as `os.environ['KLAUS_REPOS']`, this app searches `os.environ['KLAUS_REPOS']`
-    for valid git repositories and updates the application automatically when any 
+    for valid git repositories and updates the application automatically when any
     changes are made.
     This simplifies administration significantly, but may cause problems with
     large repositories.

--- a/klaus/contrib/autodiscover.py
+++ b/klaus/contrib/autodiscover.py
@@ -1,0 +1,167 @@
+import os
+import dulwich
+import logging
+import functools
+
+from klaus.repo import FancyRepo
+from klaus import Klaus, make_app
+
+try:
+    from watchdog.observers import Observer
+    from watchdog.events import (
+        FileSystemEventHandler,
+        DirCreatedEvent,
+        DirDeletedEvent,
+        DirMovedEvent
+    )
+except ImportError:
+    import sys
+    print("To automatically detect and reload repositories as they change, watchdog must be installed")
+    print("see https://pypi.python.org/pypi/watchdog/")
+    sys.exit()
+
+
+logger = logging.getLogger(__file__)
+
+def is_subdirectory(haystack, needle):
+    """
+    checks whether `needle` exists as a subdirectory of `haystack`
+    """
+    def func(arg, dirname, fnames):
+        if dirname == needle or needle in fnames:
+            logger.debug('%s is within %s', needle, haystack)
+            raise StopIteration()
+    try:
+        os.path.walk(haystack, func, None)
+    except StopIteration:
+        return True
+    return False
+
+
+class KlausEventHandler(FileSystemEventHandler):
+    """
+    Basic file-system event handler for a klaus app.
+    When git repositories are created, moved or deleted, watchdog will notify us here.
+    We try and update the klaus wsgi app with the modifications as they happen.
+    """
+    def __init__(self, klausapp, *args, **kwargs):
+        self.app = klausapp
+        return super(KlausEventHandler, self).__init__(*args, **kwargs)
+
+    def _add_dir(self, directory):
+        """
+        Attempts to register `directory` with the klaus app as a git repository.
+        If `directory` is not a git repo, this method does nothing.
+        """
+        try:
+            repo = FancyRepo(directory)
+        except dulwich.errors.NotGitRepository:
+            logger.debug("Dulwich says '%s' is not a git repository", directory)
+            return
+
+        matching = filter(lambda existing_repo: existing_repo.name == repo.name, self.app.repos)
+        if matching:
+             logger.warning("skipping repo with duplicate name:%s", repo)
+             return
+        logger.info("Adding repository, '%s' at '%s'", repo.name, directory)
+        self.app.repos.append(repo)
+
+    def on_created(self, event):
+        # We're only interested in directories; A git repo is always a directory
+        if type(event) != DirCreatedEvent:
+            return
+        logger.debug("Received directory creation event for '%s'", event.src_path)
+        self._add_dir(event.src_path)
+        self.app.update_repos_list()
+
+    def on_deleted(self, event):
+        if type(event) != DirDeletedEvent:
+            return
+        matching = filter(lambda existing_repo : existing_repo.path == event.src_path, self.app.repos)
+
+        map(lambda x: self.app.repos.remove(x), matching)
+        logger.info("%s was deleted; removing from klaus", event.src_path)
+        self.app.update_repos_list()
+
+    def on_moved(self, event):
+        """
+        Moved is not the same as deleted, unless the moved dir is no longer a subset of
+        any of the watched trees. In that case we need to consider it a deletion,
+        and remove it from the list of watched repos; otherwise we need to update its path.
+        This is a potentially expensive operation, because the only reliable way
+        to detect whether it is a subset (including symlinks etc) is to walk the path.
+        In practice, this shouldn't affect performance in the general case,
+        as moving a repository is a rare event.
+        """
+
+        matching = filter(lambda existing_repo : existing_repo.path == event.src_path, self.app.repos)
+        if not matching:
+            logger.debug("ignored non-repo move, %s -> %s", event.src_path, event.dest_path)
+            return
+
+        #first unregister old repositories
+        map(lambda x: self.app.repos.remove(x), matching)
+        # then see if the new destination is part of the klaus watchlist
+        for directory in self.app.basedirs:
+            if is_subdirectory(directory, event.dest_path):
+                logger.info("'%s' -> '%s'; updating references", event.src_path, event.dest_path)
+                self._add_dir(event.dest_path)
+
+        self.app.update_repos_list()
+        logger.info(
+            "%s was moved out of KLAUS_REPOS to %s, and is no longer a watched repository",
+            event.src_path,
+            event.dest_path
+        )
+
+
+class KlausAutoDiscover(Klaus):
+    """
+    Instead of the normal Klaus behaviour of receiving a list of git repositories
+    as `os.environ['KLAUS_REPOS']`, this app searches `os.environ['KLAUS_REPOS']`
+    for valid git repositories and updates the application automatically when any 
+    changes are made.
+    This simplifies administration significantly, but may cause problems with
+    large repositories.
+    """
+    def __init__(self, basedirs, site_name, use_smarthttp, **kwargs):
+        self.basedirs = basedirs
+        repo_paths = []
+        # first find all the existing repos in the given base directory
+        for directory in basedirs:
+            for fspath in os.listdir(directory):
+                try:
+                    path = os.path.join(directory, fspath)
+                    FancyRepo(path)  # The result is discarded. This is just a test.
+                    repo_paths.append(path)
+                except dulwich.errors.NotGitRepository:
+                    continue
+        self.observer = Observer()
+        fs_event_handler = KlausEventHandler(self)
+        # Then setup up a handler to notify us when the content of any of those directories change.
+        map(lambda directory: self.observer.schedule(fs_event_handler, directory, recursive=True), basedirs)
+        self.observer.start()
+        return super(KlausAutoDiscover, self).__init__(repo_paths, site_name, use_smarthttp, **kwargs)
+
+    def __del__(self):
+        self.observer.stop()
+
+
+if 'KLAUS_HTDIGEST_FILE' in os.environ:
+    with open(os.environ['KLAUS_HTDIGEST_FILE']) as file:
+        application = make_app(
+            os.environ['KLAUS_REPOS'].split(),
+            os.environ['KLAUS_SITE_NAME'],
+            os.environ.get('KLAUS_USE_SMARTHTTP'),
+            file,
+            KlausAutoDiscover
+        )
+else:
+    application = make_app(
+        os.environ['KLAUS_REPOS'].split(),
+        os.environ['KLAUS_SITE_NAME'],
+        os.environ.get('KLAUS_USE_SMARTHTTP'),
+        None,
+        KlausAutoDiscover
+    )
+

--- a/klaus/contrib/autodiscover.py
+++ b/klaus/contrib/autodiscover.py
@@ -1,21 +1,18 @@
 import os
 import dulwich
 import logging
+import threading
 
 from klaus.repo import FancyRepo
 from klaus import Klaus, make_app
 
 try:
     from watchdog.observers import Observer
-    from watchdog.events import (
-        FileSystemEventHandler,
-        DirCreatedEvent,
-        DirDeletedEvent,
-    )
+    from watchdog.events import FileSystemEventHandler
 except ImportError:
     import sys
-    print("To automatically detect and reload repositories as they change, watchdog must be installed")
-    print("see https://pypi.python.org/pypi/watchdog/")
+    print("To automatically detect and reload repositories as they change, watchdog must be installed.")
+    print("See https://pypi.python.org/pypi/watchdog/ for installation instructions.")
     sys.exit()
 
 
@@ -25,124 +22,159 @@ def is_subdirectory(haystack, needle):
     """
     checks whether `needle` exists as a subdirectory of `haystack`
     """
-    def func(arg, dirname, fnames):
-        if dirname == needle or needle in fnames:
-            logger.debug('%s is within %s', needle, haystack)
-            raise StopIteration()
-    try:
-        os.path.walk(haystack, func, None)
-    except StopIteration:
-        return True
-    return False
+    haystack = os.path.realpath(haystack)
+    needle = os.path.realpath(needle)
+    if not os.path.isdir(needle):
+        return False
+    return needle.startswith(haystack)
 
 
 class KlausEventHandler(FileSystemEventHandler):
     """
     Basic file-system event handler for a klaus app.
-    When git repositories are created, moved or deleted, watchdog will notify us here.
-    We try and update the klaus wsgi app with the modifications as they happen.
+    When directories are created, moved or deleted, we will be notified here.
+    We try and update the klaus wsgi app with modifications to git repos as
+    they happen.
     """
     def __init__(self, klausapp, *args, **kwargs):
-        self.app = klausapp
+        self._klausapp = klausapp
         return super(KlausEventHandler, self).__init__(*args, **kwargs)
 
-    def _add_dir(self, directory):
-        """
-        Attempts to register `directory` with the klaus app as a git repository.
-        If `directory` is not a git repo, this method does nothing.
-        """
-        try:
-            repo = FancyRepo(directory)
-        except dulwich.errors.NotGitRepository:
-            logger.debug("Dulwich says '%s' is not a git repository", directory)
+    def on_modified(self, event):
+        if not event.is_directory:
             return
-
-        matching = filter(lambda existing_repo: existing_repo.name == repo.name, self.app.repos)
-        if matching:
-             logger.warning("skipping repo with duplicate name:%s", repo)
-             return
-        logger.info("Adding repository, '%s' at '%s'", repo.name, directory)
-        self.app.repos.append(repo)
+        self._klausapp.remove_repo(event.src_path)
+        self._klausapp.add_repo(event.src_path)
 
     def on_created(self, event):
         # We're only interested in directories; A git repo is always a directory
-        if type(event) != DirCreatedEvent:
+        if not event.is_directory:
             return
         logger.debug("Received directory creation event for '%s'", event.src_path)
-        self._add_dir(event.src_path)
-        self.app.update_repos_list()
+        self._klausapp.add_repo(event.src_path)
 
     def on_deleted(self, event):
-        if type(event) != DirDeletedEvent:
+        if not event.is_directory:
             return
-        matching = filter(lambda existing_repo : existing_repo.path == event.src_path, self.app.repos)
-
-        map(lambda x: self.app.repos.remove(x), matching)
-        logger.info("%s was deleted; removing from klaus", event.src_path)
-        self.app.update_repos_list()
+        logger.debug("Received directory deletion event for '%s'", event.src_path)
+        self._klausapp.remove_repo(event.src_path)
 
     def on_moved(self, event):
         """
-        Moved is not the same as deleted, unless the moved dir is no longer a subset of
-        any of the watched trees. In that case we need to consider it a deletion,
-        and remove it from the list of watched repos; otherwise we need to update its path.
-        This is a potentially expensive operation, because the only reliable way
-        to detect whether it is a subset (including symlinks etc) is to walk the path.
-        In practice, this shouldn't affect performance in the general case,
-        as moving a repository is a rare event.
+        Moved is not the same as deleted, unless the moved dir is no longer a
+        subset of any of the watched trees. In that case we need to consider it
+        a deletion, and remove it from the list of watched repos; otherwise we
+        need to update its path. This is a potentially expensive operation,
+        because the only reliable way to detect whether it is a subset
+        (including symlinks etc) is to walk the path. In practice, this
+        shouldn't affect performance in the general case, as moving a repository
+        is a rare event.
         """
-
-        matching = filter(lambda existing_repo : existing_repo.path == event.src_path, self.app.repos)
-        if not matching:
-            logger.debug("ignored non-repo move, %s -> %s", event.src_path, event.dest_path)
-            return
-
-        #first unregister old repositories
-        map(lambda x: self.app.repos.remove(x), matching)
-        # then see if the new destination is part of the klaus watchlist
-        for directory in self.app.basedirs:
-            if is_subdirectory(directory, event.dest_path):
-                logger.info("'%s' -> '%s'; updating references", event.src_path, event.dest_path)
-                self._add_dir(event.dest_path)
-
-        self.app.update_repos_list()
-        logger.info(
-            "%s was moved out of KLAUS_REPOS to %s, and is no longer a watched repository",
+        logger.debug(
+            "Received move event:'%s'->'%s'",
             event.src_path,
             event.dest_path
         )
+        if not self._klausapp.remove_repo(event.src_path):
+            logger.debug(
+                "ignored non-repo move, %s -> %s",
+                event.src_path, event.dest_path
+            )
+            return
+
+        # first unregister old repositories
+        # then see if the new destination is part of the klaus watchlist
+        for directory in self._klausapp.basedirs:
+            if is_subdirectory(directory, event.dest_path):
+                logger.info(
+                    "'%s' -> '%s'; updating references",
+                    event.src_path,
+                    event.dest_path
+                )
+                self._klausapp.add_repo(event.dest_path)
+                break
+        else:
+            logger.info(
+                "%s was moved out of KLAUS_REPOS to %s, and is now ignored",
+                event.src_path,
+                event.dest_path
+            )
 
 
 class KlausAutoDiscover(Klaus):
     """
-    Instead of the normal Klaus behaviour of receiving a list of git repositories
-    as `os.environ['KLAUS_REPOS']`, this app searches `os.environ['KLAUS_REPOS']`
-    for valid git repositories and updates the application automatically when any
-    changes are made.
-    This simplifies administration significantly, but may cause problems with
-    large repositories.
+    Instead of the normal Klaus behaviour of receiving a list of git
+    repositories as `os.environ['KLAUS_REPOS']`, this searches
+    `os.environ['KLAUS_REPOS']` for valid git repositories and updates klaus
+    automatically when any changes are made. if `recursive=True`, klaus will
+    watch every subdirectory in the given directories, and discover all git
+    repositories therein. This simplifies administration significantly, but may
+    cause problems with large repositories, as the underlying file watch
+    mechanisms don't expose a recursion depth parameter on any of the common
+    platforms (Linux, win32, OS X).
     """
     def __init__(self, basedirs, site_name, use_smarthttp, **kwargs):
-        self.basedirs = basedirs
-        repo_paths = []
-        # first find all the existing repos in the given base directory
+        recursive = kwargs.pop('recursive', False)
+        super(KlausAutoDiscover, self).__init__([], site_name, use_smarthttp, **kwargs)
+        self._lock = threading.RLock()
+        self._basedirs = basedirs
+        self._observer = Observer()
+
+        # First find and add all the existing repos in the given base directory.
         for directory in basedirs:
             for fspath in os.listdir(directory):
-                try:
-                    path = os.path.join(directory, fspath)
-                    FancyRepo(path)  # The result is discarded. This is just a test.
-                    repo_paths.append(path)
-                except dulwich.errors.NotGitRepository:
-                    continue
-        self.observer = Observer()
+                path = os.path.join(directory, fspath)
+                self.add_repo(path)
+
+        # Then create a handler to notify us of any changes within those dirs.
         fs_event_handler = KlausEventHandler(self)
-        # Then setup up a handler to notify us when the content of any of those directories change.
-        map(lambda directory: self.observer.schedule(fs_event_handler, directory, recursive=True), basedirs)
-        self.observer.start()
-        return super(KlausAutoDiscover, self).__init__(repo_paths, site_name, use_smarthttp, **kwargs)
+        for directory in basedirs:
+            self._observer.schedule(fs_event_handler, directory, recursive=recursive)
+
+        self._observer.start()
+
+    def add_repo(self, directory):
+        """
+        Attempts to register `directory` with the klaus app as a git repository.
+        If `directory` is not a git repo, this method does nothing.
+        """
+        with self._lock:
+            try:
+                repo = FancyRepo(directory)
+            except dulwich.errors.NotGitRepository:
+                logger.debug("Dulwich says '%s' is not a git repository", directory)
+                return
+
+            if self.repo_map.get(repo.name):
+                logger.debug("skipping repo with duplicate name:%s", repo)
+                return
+            logger.info("Adding repository, '%s' at '%s'", repo.name, directory)
+            self.repo_map[repo.name] = repo
+
+    def remove_repo(self, directory):
+        """
+        given a filesystem path, `directory` attempts to remove the
+        corresponding repository from the list of watched repositories.
+        """
+        with self._lock:
+            key_map = dict(zip(
+                (repo.path for repo in self.repo_map.values()),
+                self.repo_map)
+            )
+            try:
+                name = key_map[directory]
+                del self.repo_map[name]
+                return True
+            except KeyError:
+                logger.debug(
+                    "couldn't delete '%s'; not an existing repository",
+                    directory
+                )
+                pass
 
     def __del__(self):
-        self.observer.stop()
+        self._observer.stop()
+        self._observer.join()
 
 
 if 'KLAUS_HTDIGEST_FILE' in os.environ:
@@ -152,7 +184,8 @@ if 'KLAUS_HTDIGEST_FILE' in os.environ:
             os.environ['KLAUS_SITE_NAME'],
             os.environ.get('KLAUS_USE_SMARTHTTP'),
             file,
-            KlausAutoDiscover
+            KlausAutoDiscover,
+            recursive=os.environ.get('KLAUS_DISCOVER_RECURSIVE')
         )
 else:
     application = make_app(
@@ -160,6 +193,6 @@ else:
         os.environ['KLAUS_SITE_NAME'],
         os.environ.get('KLAUS_USE_SMARTHTTP'),
         None,
-        KlausAutoDiscover
+        KlausAutoDiscover,
+        recursive=os.environ.get('KLAUS_DISCOVER_RECURSIVE')
     )
-

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -22,7 +22,7 @@ def repo_list():
     else:
         sort_key = lambda repo: repo.name
         reverse = False
-    repos = sorted(current_app.repos, key=sort_key, reverse=reverse)
+    repos = sorted(current_app.repo_map.values(), key=sort_key, reverse=reverse)
     return render_template('repo_list.html', repos=repos)
 
 def robots_txt():


### PR DESCRIPTION
...es in KLAUS_REPOS. `klaus.contrib.autodiscover:application`

Also watches for changes to KLAUS_REPOS using the most efficient filesystem notifier available on the system (pip install watchdog)

I made slight changes to `klaus.Klaus` to enable the integration with the filesystem watcher, but these changes should be backwards-compatible.
Usage of the new autodiscover module requires [`watchdog`](https://pypi.python.org/pypi/watchdog/)

This new wsgi application significantly eases administrative burden when creating/deleting/moving git repositories.  The web server no-longer requires a restart.
