### PR TITLE
Fix errant .split() calls that causes a TypeError

### DIFF
--- a/klaus/contrib/wsgi_autoreload.py
+++ b/klaus/contrib/wsgi_autoreload.py
@@ -52,14 +52,14 @@ def make_autoreloading_app(repos_root, *args, **kwargs):
 if 'KLAUS_HTDIGEST_FILE' in os.environ:
     with open(os.environ['KLAUS_HTDIGEST_FILE']) as file:
         application = make_app(
-            os.environ['KLAUS_REPOS'].split(),
+            os.environ['KLAUS_REPOS'],
             os.environ['KLAUS_SITE_NAME'],
             os.environ.get('KLAUS_USE_SMARTHTTP'),
             file,
         )
 else:
     application = make_autoreloading_app(
-        os.environ['KLAUS_REPOS'].split(),
+        os.environ['KLAUS_REPOS'],
         os.environ['KLAUS_SITE_NAME'],
         os.environ.get('KLAUS_USE_SMARTHTTP'),
         None,


### PR DESCRIPTION
Fix errant .split() calls that causes a TypeError when trying to use the wsgi_autoreload component

Fixed #116