### PR TITLE
allow to specify repositories root

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,6 @@ Gunicorn example::
             --env KLAUS_REPOS="/path/to/repo1 /path/to/repo2 ..." \
             klaus.contrib.wsgi
 
-See also `deploymeny section in the wiki <https://github.com/jonashaag/klaus/wiki#deployment>`_.
+See also `deployment section in the wiki <https://github.com/jonashaag/klaus/wiki#deployment>`_.
 
 .. _wsgiref: http://docs.python.org/library/wsgiref.html

--- a/klaus/contrib/wsgi_autoreload.py
+++ b/klaus/contrib/wsgi_autoreload.py
@@ -1,8 +1,9 @@
 import os
 import time
 import threading
-from klaus import make_app
+import warnings
 
+from klaus import make_app
 
 # Shared state between poller and application wrapper
 class _:
@@ -49,18 +50,20 @@ def make_autoreloading_app(repos_root, *args, **kwargs):
     return app
 
 
+if 'KLAUS_REPOS' in os.environ:
+    warnings.warn("use KLAUS_REPOS_ROOT instead of KLAUS_REPOS for the autoreloader apps", DeprecationWarning)
+
 if 'KLAUS_HTDIGEST_FILE' in os.environ:
     with open(os.environ['KLAUS_HTDIGEST_FILE']) as file:
-        application = make_app(
-            os.environ['KLAUS_REPOS'],
+        application = make_autoreloading_app(
+            os.environ.get('KLAUS_REPOS_ROOT') or os.environ['KLAUS_REPOS'],
             os.environ['KLAUS_SITE_NAME'],
             os.environ.get('KLAUS_USE_SMARTHTTP'),
             file,
         )
 else:
     application = make_autoreloading_app(
-        os.environ['KLAUS_REPOS'],
+        os.environ.get('KLAUS_REPOS_ROOT') or os.environ['KLAUS_REPOS'],
         os.environ['KLAUS_SITE_NAME'],
         os.environ.get('KLAUS_USE_SMARTHTTP'),
-        None,
     )


### PR DESCRIPTION
hi,
it looks like `make_autoreloading_app` doesnt really work right now - it accepts `KLAUS_REPOS` as a param (which is supposed to be a list of directories), but when it spawns a thread to monitor changes later, it expects just a single directory there.

So I've added another env variable `KLAUS_REPOS_ROOT`, which can be used for specifying a parent directory for repositories in it, instead of defining a list of repositories explicitly.

This change is backward compatible, as it fallbacks to `KLAUS_REPOS` in case `KLAUS_REPOS_ROOT` is not defined.