### PR TITLE
Cool new feature: Mirror any tree-ish object.

### DIFF
--- a/klaus/repo.py
+++ b/klaus/repo.py
@@ -112,8 +112,8 @@ class FancyRepo(dulwich.repo.Repo):
 
     def get_blob_or_tree(self, commit, path):
         """ Returns the Git tree or blob object for `path` at `commit`. """
-        tree_or_blob = self[commit.tree]  # Still a tree here but may turn into
-                                          # a blob somewhere in the loop.
+        tree_or_blob = self[getattr(commit, 'tree', commit.id)]  # Still a tree here but may turn into
+                                                                 # a blob somewhere in the loop.
         for part in path.strip('/').split('/'):
             if part:
                 if isinstance(tree_or_blob, dulwich.objects.Blob):

--- a/klaus/templates/raw_tree.html
+++ b/klaus/templates/raw_tree.html
@@ -1,0 +1,17 @@
+{% extends 'skeleton.html' %}
+
+{% block content %}
+<div class=tree>
+  <h2>Tree @{{ rev|shorten_sha1 }}
+  <span>(<a href="{{ url_for('raw', repo=repo.name, rev=root_tree.sha1) }}">raw&nbsp;tree</a>)</span>
+  </h2>
+  <ul>
+    {% for _, name, fullpath in root_tree.dirs %}
+    <li><a href="{{ url_for('raw', repo=repo.name, rev=rev, path=fullpath) }}" class=dir>{{ name|force_unicode }}</a></li>
+    {% endfor %}
+    {% for _, name, fullpath in root_tree.files %}
+    <li><a href="{{ url_for('raw', repo=repo.name, rev=rev, path=fullpath) }}">{{ name|force_unicode }}</a></li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/klaus/templates/tree.inc.html
+++ b/klaus/templates/tree.inc.html
@@ -1,6 +1,7 @@
 <div class=tree>
   <h2>Tree @<a href="{{ url_for('commit', repo=repo.name, rev=rev) }}">{{ rev|shorten_sha1 }}</a>
-    <span>(<a href="{{ url_for('download', repo=repo.name, rev=rev) }}">Download .tar.gz</a>)</span>
+    <span>(<a href="{{ url_for('raw', repo=repo.name, rev=root_tree.sha1) }}">raw&nbsp;tree</a>)
+    (<a href="{{ url_for('download', repo=repo.name, rev=rev) }}">Download .tar.gz</a>)</span>
   </h2>
   <ul>
     {% for _, name, fullpath in root_tree.dirs %}


### PR DESCRIPTION
This pull request extends klaus to enable automated retrieval of any tree-ish object within the repository. It extends the raw view to present a modified raw tree template whenever a raw tree is requested.

This raw tree template is analogous to a directory index page. It presents links to child trees and contained blobs. Each link has a common parent and follows URL path semantics.

Mirroring software or other software expecting a directory index can follow these links, download raw blobs, and re-create the directory structure directly from the git repository without needing to be git savvy.

The URL for this feature is <repo>/raw/<tree-ish>/<path>

Try it with wget --recursive --noparent