### PR TITLE
Add a go-import meta tag, necessary for go get to work

### DIFF
--- a/bin/klaus
+++ b/bin/klaus
@@ -30,6 +30,7 @@ def make_parser():
     parser.add_argument('--host',     help="default: 127.0.0.1", default='127.0.0.1')
     parser.add_argument('--port',     help="default: 8080", default=8080, type=int)
     parser.add_argument('--site-name', help="site name showed in header. default: your hostname")
+    parser.add_argument('--domain-name', help="domain name (used for the go import meta tag)")
     parser.add_argument('--version', help='print version number', action='store_true')
     parser.add_argument('-b', '--browser', help="open klaus in a browser on server start",
                         default=False, action='store_true')
@@ -84,6 +85,7 @@ def main():
     app = make_app(
         args.repos,
         force_unicode(args.site_name or args.host),
+        args.domain_name,
         args.smarthttp,
         args.htdigest,
         ctags_policy=args.ctags,

--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -15,11 +15,12 @@ class Klaus(flask.Flask):
         'undefined': jinja2.StrictUndefined
     }
 
-    def __init__(self, repo_paths, site_name, use_smarthttp, ctags_policy='none'):
+    def __init__(self, repo_paths, site_name, domain_name, use_smarthttp, ctags_policy='none'):
         """(See `make_app` for parameter descriptions.)"""
         repo_objs = [FancyRepo(path) for path in repo_paths]
         self.repos = dict((repo.name, repo) for repo in repo_objs)
         self.site_name = site_name
+        self.domain_name = domain_name
         self.use_smarthttp = use_smarthttp
         self.ctags_policy = ctags_policy
 
@@ -43,6 +44,7 @@ class Klaus(flask.Flask):
         env.globals['KLAUS_VERSION'] = KLAUS_VERSION
         env.globals['USE_SMARTHTTP'] = self.use_smarthttp
         env.globals['SITE_NAME'] = self.site_name
+        env.globals['DOMAIN_NAME'] = self.domain_name
 
         return env
 
@@ -78,7 +80,7 @@ class Klaus(flask.Flask):
 
 
 
-def make_app(repo_paths, site_name, use_smarthttp=False, htdigest_file=None,
+def make_app(repo_paths, site_name, domain_name="", use_smarthttp=False, htdigest_file=None,
              require_browser_auth=False, disable_push=False, unauthenticated_push=False,
              ctags_policy='none'):
     """
@@ -87,6 +89,7 @@ def make_app(repo_paths, site_name, use_smarthttp=False, htdigest_file=None,
 
     :param repo_paths: List of paths of repositories to serve.
     :param site_name: Name of the Web site (e.g. "John Doe's Git Repositories")
+    :param domain_name: Domain name
     :param use_smarthttp: Enable Git Smart HTTP mode, which makes it possible to
         pull from the served repositories. If `htdigest_file` is set as well,
         also allow to push for authenticated users.
@@ -117,6 +120,7 @@ def make_app(repo_paths, site_name, use_smarthttp=False, htdigest_file=None,
     app = Klaus(
         repo_paths,
         site_name,
+        domain_name,
         use_smarthttp,
         ctags_policy,
     )

--- a/klaus/contrib/wsgi.py
+++ b/klaus/contrib/wsgi.py
@@ -6,6 +6,7 @@ if 'KLAUS_HTDIGEST_FILE' in os.environ:
         application = make_app(
             os.environ['KLAUS_REPOS'].split(),
             os.environ['KLAUS_SITE_NAME'],
+            os.environ.get('KLAUS_DOMAIN_NAME'),
             os.environ.get('KLAUS_USE_SMARTHTTP'),
             file,
         )
@@ -13,6 +14,7 @@ else:
     application = make_app(
         os.environ['KLAUS_REPOS'].split(),
         os.environ['KLAUS_SITE_NAME'],
+        os.environ.get('KLAUS_DOMAIN_NAME'),
         os.environ.get('KLAUS_USE_SMARTHTTP'),
         None,
     )

--- a/klaus/templates/history.html
+++ b/klaus/templates/history.html
@@ -6,7 +6,7 @@
   {{ super() }}
 {% endblock %}
 
-{% block goimport %}<meta name="go-import" content="{{ DOMAIN_NAME }}/{{ repo.name }} git {{ url_for('repo_list', _external=True) }}{{repo.name }}/" />{% endblock %}
+{% block goimport %}<meta name="go-import" content="{{ DOMAIN_NAME }}/{{ repo.name }} git {{ url_for('repo_list', _external=True) }}{{repo.name }}" />{% endblock %}
 
 {% block content %}
 

--- a/klaus/templates/history.html
+++ b/klaus/templates/history.html
@@ -6,6 +6,8 @@
   {{ super() }}
 {% endblock %}
 
+{% block goimport %}<meta name="go-import" content="{{ DOMAIN_NAME }}/{{ repo.name }} git {{ url_for('repo_list', _external=True) }}{{repo.name }}/" />{% endblock %}
+
 {% block content %}
 
 {% include 'tree.inc.html' %}

--- a/klaus/templates/skeleton.html
+++ b/klaus/templates/skeleton.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <title>{% block title %}{% endblock %} - {{ SITE_NAME }}</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
+{% block goimport %}{% endblock %}
 <link rel=stylesheet href={{ url_for('static', filename='pygments.css') }}>
 <link rel=stylesheet href={{ url_for('static', filename='klaus.css') }}>
 <link rel=icon type="image/png" href="{{ url_for('static', filename='favicon.png') }}" />


### PR DESCRIPTION
Hi,

discovered klaus yesterday, extremely happy with it, thanks a lot :)

I mostly work with Go and one thing I wanted to be able to do is make my projects "go get-able" meaning you could run `go get git.mydomain.com/myproject` and it would work.

By default go get works with popular source hosting services like github, bitbucket, and there's a way to make it handle any custom url: you put a simple <meta> tag on any url you want which points `go get` to the git url repository.

I'm not sure if it's really something you would want to include because it's a super niche feature in my opinion, but I figured since I made the patch might as well share it.