### PR TITLE
Wsgi autoreload recursive

### DIFF
--- a/klaus/contrib/wsgi_autoreload_recursive.py
+++ b/klaus/contrib/wsgi_autoreload_recursive.py
@@ -1,0 +1,80 @@
+from __future__ import print_function
+import os
+import time
+import threading
+import warnings
+
+from klaus import make_app
+
+# Shared state between poller and application wrapper
+class _:
+    #: the real WSGI app
+    inner_app = None
+    should_reload = True
+
+
+def find_git_repos_recursive(dir):
+    repos = []
+    for dirpath, dirs, files in os.walk(dir):
+        if '.git' in dirs:
+            repos.append(dirpath)
+            map(dirs.remove, dirs)
+    print(repos)
+    return repos
+
+
+def poll_for_changes(interval, dir):
+    """
+    Polls `dir` for changes every `interval` seconds and sets `should_reload`
+    accordingly.
+    """
+    old_contents = find_git_repos_recursive(dir)
+    while 1:
+        time.sleep(interval)
+        if _.should_reload:
+            # klaus application has not seen our change yet
+            continue
+        new_contents = find_git_repos_recursive(dir)
+        if new_contents != old_contents:
+            # Directory contents changed => should_reload
+            old_contents = new_contents
+            _.should_reload = True
+
+
+def make_autoreloading_app(repos_root, *args, **kwargs):
+    def app(environ, start_response):
+        if _.should_reload:
+            # Refresh inner application with new repo list
+            print("Reloading repository list...")
+            _.inner_app = make_app(
+                [os.path.join(repos_root, x) for x in find_git_repos_recursive(repos_root)],
+                *args, **kwargs
+            )
+            _.should_reload = False
+        return _.inner_app(environ, start_response)
+
+    # Background thread that polls the directory for changes
+    poller_thread = threading.Thread(target=(lambda: poll_for_changes(10, repos_root)))
+    poller_thread.daemon = True
+    poller_thread.start()
+
+    return app
+
+
+if 'KLAUS_REPOS' in os.environ:
+    warnings.warn("use KLAUS_REPOS_ROOT instead of KLAUS_REPOS for the autoreloader apps", DeprecationWarning)
+
+if 'KLAUS_HTDIGEST_FILE' in os.environ:
+    with open(os.environ['KLAUS_HTDIGEST_FILE']) as file:
+        application = make_autoreloading_app(
+            os.environ.get('KLAUS_REPOS_ROOT') or os.environ['KLAUS_REPOS'],
+            os.environ['KLAUS_SITE_NAME'],
+            os.environ.get('KLAUS_USE_SMARTHTTP'),
+            file,
+        )
+else:
+    application = make_autoreloading_app(
+        os.environ.get('KLAUS_REPOS_ROOT') or os.environ['KLAUS_REPOS'],
+        os.environ['KLAUS_SITE_NAME'],
+        os.environ.get('KLAUS_USE_SMARTHTTP'),
+    )

--- a/klaus/contrib/wsgi_autoreload_recursive.py
+++ b/klaus/contrib/wsgi_autoreload_recursive.py
@@ -19,7 +19,6 @@ def find_git_repos_recursive(dir):
         if '.git' in dirs:
             repos.append(dirpath)
             map(dirs.remove, dirs)
-    print(repos)
     return repos
 
 


### PR DESCRIPTION
Ripped off `klaus/contrib/wsgi_autoreload.py` and modified it to find git repos contained in a directory recursively.

Useful when KLAUS_REPOS_ROOT has a layout such as:

```
|-- directory1
|    -- repo1
|-- directory2
|    -- repo2
|-- repo3
```
