### PR TITLE
Support gitweb .git/cloneurl file and 'gitweb.url' settings.

### DIFF
--- a/klaus/repo.py
+++ b/klaus/repo.py
@@ -32,6 +32,18 @@ class FancyRepo(dulwich.repo.Repo):
             return refs[0].commit_time
         return None
 
+    @property
+    def cloneurl(self):
+        """Retrieve the gitweb notion of the public clone URL of this repo."""
+        f = self.get_named_file('cloneurl')
+        if f is not None:
+            return f.read()
+        c = self.get_config()
+        try:
+            return force_unicode(c.get(b'gitweb', b'url'))
+        except KeyError:
+            return None
+
     def get_description(self):
         """Like Dulwich's `get_description`, but returns None if the file
         contains Git's default text "Unnamed repository[...]".

--- a/klaus/templates/history.inc.html
+++ b/klaus/templates/history.inc.html
@@ -37,6 +37,9 @@
     {% if USE_SMARTHTTP %}
         <code>git clone {{ url_for('index', repo=repo.name, _external=True) }}</code>
     {% endif %}
+    {% if repo.cloneurl %}
+        <code>git clone {{ repo.cloneurl }}</code>
+    {% endif %}
   </h2>
 
   {{ pagination() }}


### PR DESCRIPTION
This addresses #122 when the smart server is disabled.

At the moment this displays the URL in addition to the smart server URL if repo.cloneurl is set.