### PR TITLE
Link to index page rather than history page.

### DIFF
--- a/klaus/templates/base.html
+++ b/klaus/templates/base.html
@@ -6,7 +6,7 @@
 
 {% block breadcrumbs %}
   <span>
-    <a href="{{ url_for('history', repo=repo.name) }}">{{ repo.name }}</a>
+    <a href="{{ url_for('index', repo=repo.name) }}">{{ repo.name }}</a>
     <span class=slash>/</span>
     <a href="{{ url_for('history', repo=repo.name, rev=rev) }}">{{ rev|shorten_sha1 }}</a>
   </span>


### PR DESCRIPTION
fd0ee00949c9aad3140d5d850864ae43fb9ea40a deleted the /history page.