### PR TITLE
Handle refs that contain a / properly

### DIFF
--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -60,6 +60,7 @@ class Klaus(flask.Flask):
             ('patch',       '/<repo>/commit/<rev>.diff'),
             ('patch',       '/<repo>/commit/<rev>.patch'),
             ('index',       '/<repo>/'),
+            ('index',       '/<repo>/<path:rev>'),
             ('history',     '/<repo>/tree/<rev>/'),
             ('history',     '/<repo>/tree/<rev>/<path:path>'),
             ('download',    '/<repo>/tarball/<rev>/'),

--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -50,20 +50,20 @@ class Klaus(flask.Flask):
         for endpoint, rule in [
             ('repo_list',   '/'),
             ('robots_txt',  '/robots.txt/'),
-            ('blob',        '/<repo>/blob/<rev>/'),
+            ('blob',        '/<repo>/blob/'),
             ('blob',        '/<repo>/blob/<rev>/<path:path>'),
-            ('blame',       '/<repo>/blame/<rev>/'),
+            ('blame',       '/<repo>/blame/'),
             ('blame',       '/<repo>/blame/<rev>/<path:path>'),
-            ('raw',         '/<repo>/raw/<rev>/'),
+            ('raw',         '/<repo>/raw/<path:path>/'),
             ('raw',         '/<repo>/raw/<rev>/<path:path>'),
-            ('commit',      '/<repo>/commit/<rev>/'),
-            ('patch',       '/<repo>/commit/<rev>.diff'),
-            ('patch',       '/<repo>/commit/<rev>.patch'),
+            ('commit',      '/<repo>/commit/<path:rev>/'),
+            ('patch',       '/<repo>/commit/<path:rev>.diff'),
+            ('patch',       '/<repo>/commit/<path:rev>.patch'),
             ('index',       '/<repo>/'),
             ('index',       '/<repo>/<path:rev>'),
-            ('history',     '/<repo>/tree/<rev>/'),
+            ('history',     '/<repo>/tree/<rev>'),
             ('history',     '/<repo>/tree/<rev>/<path:path>'),
-            ('download',    '/<repo>/tarball/<rev>/'),
+            ('download',    '/<repo>/tarball/<path:rev>/'),
         ]:
             self.add_url_rule(rule, view_func=getattr(views, endpoint))
 

--- a/klaus/templates/base.html
+++ b/klaus/templates/base.html
@@ -31,13 +31,13 @@
   <div>
     <ul class=branches>
       {% for branch in branches %}
-      <li><a href="{{ url_for(view, repo=repo.name, rev=branch, path=path) }}">{{ branch }}</a></li>
+      <li><a href="{{ url_for(view, repo=repo.name, rev=branch, path=(path or None)) }}">{{ branch }}</a></li>
       {% endfor %}
     </ul>
     {% if tags %}
     <ul class=tags>
       {% for tag in tags %}
-      <li><a href="{{ url_for(view, repo=repo.name, rev=tag, path=path) }}">{{ tag }}</a></li>
+      <li><a href="{{ url_for(view, repo=repo.name, rev=tag, path=(path or None)) }}">{{ tag }}</a></li>
       {% endfor %}
     </ul>
     {% endif %}

--- a/klaus/utils.py
+++ b/klaus/utils.py
@@ -246,3 +246,9 @@ def guess_git_revision():
         # Either the git executable couldn't be found in the OS's PATH
         # or no ".git" directory exists, i.e. this is no "bleeding-edge" installation.
         return None
+
+
+def sanitize_branch_name(name, chars='./', repl='-'):
+    for char in chars:
+        name = name.replace(char, repl)
+    return name

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -258,7 +258,9 @@ class IndexView(TreeViewMixin, BaseRepoView):
         })
         try:
             (readme_filename, readme_data) = self._get_readme()
+            print(readme_filename)
         except KeyError:
+            print("no readme")
             self.context.update({
                 'is_markup': None,
                 'rendered_code': None,


### PR DESCRIPTION
This fixes two bugs:

* #36 is fixed by forward-porting closed PR #103 
* The drop-down list of branches doesn't work on the index page because query string parameters aren't parsed; this adds parsing so that the rev can be specified in the query string.