### PR TITLE
Drop support for Python2.6. Fixes #184

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-import glob
 from setuptools import setup
 
 
@@ -15,13 +14,7 @@ def install_data_files_hack():
 
 install_data_files_hack()
 
-requires = ['six', 'flask', 'pygments', 'dulwich>=0.13.0', 'httpauth', 'humanize']
-
-try:
-    import argparse  # not available for Python 2.6
-except ImportError:
-    requires.append('argparse')
-
+requires = ['argparse', 'six', 'flask', 'pygments', 'dulwich>=0.13.0', 'httpauth', 'humanize']
 
 setup(
     name='klaus',
@@ -44,7 +37,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: ISC License (ISCL)",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
     ],
     install_requires=requires,


### PR DESCRIPTION
pygments also no longer supports 2.6.

This should fix the build on travis.