### PR TITLE
Fix bug when the latest ref on a repo is a tag

### DIFF
--- a/klaus/repo.py
+++ b/klaus/repo.py
@@ -30,8 +30,11 @@ class FancyRepo(dulwich.repo.Repo):
         refs = [self[ref_hash] for ref_hash in self.get_refs().values()]
         refs.sort(key=lambda obj:getattr(obj, 'commit_time', float('-inf')),
                   reverse=True)
-        if refs:
-            return refs[0].commit_time
+        for ref in refs:
+            # Find the latest ref that has a commit_time; tags do not
+            # have a commit time
+            if hasattr(ref, "commit_time"):
+                return ref.commit_time
         return None
 
     @property


### PR DESCRIPTION
Tags do not have commit times, but they do appear in the list of
refs. This makes klaus use the latest ref that has a commit_time when
finding the last updated time for a repo.

The easiest way to replicate this is with a repo that contains no commits, only a tag.