### PR TITLE
Link submodules to an info page, rather than showing a 404.

### DIFF
--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -56,6 +56,8 @@ class Klaus(flask.Flask):
             ('blame',       '/<repo>/blame/<rev>/<path:path>'),
             ('raw',         '/<repo>/raw/<path:path>/'),
             ('raw',         '/<repo>/raw/<rev>/<path:path>'),
+            ('submodule',   '/<repo>/submodule/<rev>'),
+            ('submodule',   '/<repo>/submodule/<rev>/<path:path>'),
             ('commit',      '/<repo>/commit/<path:rev>/'),
             ('patch',       '/<repo>/commit/<path:rev>.diff'),
             ('patch',       '/<repo>/commit/<path:rev>.patch'),

--- a/klaus/templates/submodule.html
+++ b/klaus/templates/submodule.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+{% block title %}
+  {{ path }} - {{ super() }}
+{% endblock %}
+
+{% block content %}
+
+<h2>
+{{ path|force_unicode }}
+<span>
+  @<a href="{{ url_for('commit', repo=repo.name, rev=rev) }}">{{ rev|shorten_sha1 }}</a>
+</span>
+</h2>
+<p>The path at {{ path|force_unicode }} contains a submodule, revision {{ submodule_rev }}.  {% if submodule_url %} It can be checked out from <a href="{{ submodule_url }}">{{ submodule_url }}</a>. {% endif %}
+</p>
+
+{% endblock %}

--- a/klaus/templates/tree.inc.html
+++ b/klaus/templates/tree.inc.html
@@ -6,6 +6,9 @@
     {% for _, name, fullpath in root_tree.dirs %}
     <li><a href="{{ url_for('history', repo=repo.name, rev=rev, path=fullpath) }}" class=dir>{{ name|force_unicode }}</a></li>
     {% endfor %}
+    {% for _, name, fullpath, submodulerev in root_tree.submodules %}
+    <li><a href="{{ url_for('submodule', repo=repo.name, rev=rev, path=fullpath) }}" class=submodule>{{ name|force_unicode }}</a></li>
+    {% endfor %}
     {% for _, name, fullpath in root_tree.files %}
     <li><a href="{{ url_for('blob', repo=repo.name, rev=rev, path=fullpath) }}">{{ name|force_unicode }}</a></li>
     {% endfor %}


### PR DESCRIPTION
Currently, this just shows some basic information about the submodule -
i.e. where the repository can be cloned from, and the revision that is
referenced.

Partially addresses #1. In the future, this page could redirect to the
actual submodule repository history page.