### PR TITLE
Drop argparse requirement (included in Python 2.7+)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def install_data_files_hack():
 
 install_data_files_hack()
 
-requires = ['argparse', 'six', 'flask', 'pygments', 'dulwich>=0.13.0', 'httpauth', 'humanize']
+requires = ['six', 'flask', 'pygments', 'dulwich>=0.13.0', 'httpauth', 'humanize']
 
 setup(
     name='klaus',


### PR DESCRIPTION
HI, I guess this isn't needed since https://github.com/jonashaag/klaus/commit/7cc4c13a95ac9ea023e1ab2a383bfb38098bb0e1