### PR TITLE
Splitted contrib.wsgi_autoreload

### DIFF
--- a/klaus/contrib/app_args.py
+++ b/klaus/contrib/app_args.py
@@ -8,7 +8,7 @@ def get_args_from_env():
         repos = repos.split()
     args = (
         repos,
-        os.environ['KLAUS_SITE_NAME']
+        os.environ.get('KLAUS_SITE_NAME', 'unnamed site')
     )
     kwargs = dict(
         htdigest_file=os.environ.get('KLAUS_HTDIGEST_FILE'),

--- a/klaus/contrib/wsgi_autoreload.py
+++ b/klaus/contrib/wsgi_autoreload.py
@@ -1,57 +1,8 @@
-from __future__ import print_function
 import os
-import time
-import threading
 import warnings
-from io import open, StringIO
 
-from klaus import make_app
 from .app_args import get_args_from_env
-
-
-# Shared state between poller and application wrapper
-class _:
-    #: the real WSGI app
-    inner_app = None
-    should_reload = True
-
-
-def poll_for_changes(interval, dir):
-    """
-    Polls `dir` for changes every `interval` seconds and sets `should_reload`
-    accordingly.
-    """
-    old_contents = os.listdir(dir)
-    while 1:
-        time.sleep(interval)
-        if _.should_reload:
-            # klaus application has not seen our change yet
-            continue
-        new_contents = os.listdir(dir)
-        if new_contents != old_contents:
-            # Directory contents changed => should_reload
-            old_contents = new_contents
-            _.should_reload = True
-
-
-def make_autoreloading_app(repos_root, *args, **kwargs):
-    def app(environ, start_response):
-        if _.should_reload:
-            # Refresh inner application with new repo list
-            print("Reloading repository list...")
-            _.inner_app = make_app(
-                [os.path.join(repos_root, x) for x in os.listdir(repos_root)],
-                *args, **kwargs
-            )
-            _.should_reload = False
-        return _.inner_app(environ, start_response)
-
-    # Background thread that polls the directory for changes
-    poller_thread = threading.Thread(target=(lambda: poll_for_changes(10, repos_root)))
-    poller_thread.daemon = True
-    poller_thread.start()
-
-    return app
+from .wsgi_autoreloading import make_autoreloading_app
 
 
 if 'KLAUS_REPOS' in os.environ:

--- a/klaus/contrib/wsgi_autoreloading.py
+++ b/klaus/contrib/wsgi_autoreloading.py
@@ -1,0 +1,53 @@
+from __future__ import print_function
+import os
+import time
+import threading
+from io import open, StringIO
+
+from klaus import make_app
+
+
+# Shared state between poller and application wrapper
+class _:
+    #: the real WSGI app
+    inner_app = None
+    should_reload = True
+
+
+def poll_for_changes(interval, dir):
+    """
+    Polls `dir` for changes every `interval` seconds and sets `should_reload`
+    accordingly.
+    """
+    old_contents = os.listdir(dir)
+    while 1:
+        time.sleep(interval)
+        if _.should_reload:
+            # klaus application has not seen our change yet
+            continue
+        new_contents = os.listdir(dir)
+        if new_contents != old_contents:
+            # Directory contents changed => should_reload
+            old_contents = new_contents
+            _.should_reload = True
+
+
+def make_autoreloading_app(repos_root, *args, **kwargs):
+    def app(environ, start_response):
+        if _.should_reload:
+            # Refresh inner application with new repo list
+            print("Reloading repository list...")
+            _.inner_app = make_app(
+                [os.path.join(repos_root, x) for x in os.listdir(repos_root)],
+                *args, **kwargs
+            )
+            _.should_reload = False
+        return _.inner_app(environ, start_response)
+
+    # Background thread that polls the directory for changes
+    poller_thread = threading.Thread(target=(lambda: poll_for_changes(10, repos_root)))
+    poller_thread.daemon = True
+    poller_thread.start()
+
+    return app
+


### PR DESCRIPTION
as discussed in #195. Both running klaus.contrib.wsgi_autoreload from uwsgi and using klaus.contrib.wsgi_autoreloading in a script (with mod_wsgi) tested fine. Will adapt the apache docs for it.