### PR TITLE
Fixes #144 - Blank Git user config for tests

### DIFF
--- a/tests/repos/scripts/dont-render
+++ b/tests/repos/scripts/dont-render
@@ -1,4 +1,9 @@
 #!/bin/bash -e
+
+# This should prevent this script to load the local git user config: 
+# (HOME overwrite)
+HOME="."
+
 git init
 
 # Create binary
@@ -13,4 +18,4 @@ git add image.jpg
 yes | head -n 102400 > toolarge
 git add toolarge
 
-git commit --no-gpg-sign -am first
+git commit -am first

--- a/tests/repos/scripts/no-newline-at-end-of-file
+++ b/tests/repos/scripts/no-newline-at-end-of-file
@@ -1,12 +1,17 @@
 #!/bin/bash -e
+
+# This should prevent this script to load the local git user config: 
+# (HOME overwrite)
+HOME="."
+
 git init
 
 echo 1 > test
 echo -n 2 >> test
 git add test
-git commit --no-gpg-sign -m old
+git commit -m old
 
 echo 1 > test
 echo 2 >> test
 git add test
-git commit --no-gpg-sign -m new
+git commit -m new

--- a/tests/repos/scripts/test_repo
+++ b/tests/repos/scripts/test_repo
@@ -1,13 +1,18 @@
 #!/bin/bash -e
+
+# This should prevent this script to load the local git user config: 
+# (HOME overwrite)
+HOME="."
+
 git init
 
 echo "int a;" > test.c
 echo "function test() {}" > test.js
 git add test.c
 git add test.js
-git commit --no-gpg-sign -m "Add some code"
+git commit -m "Add some code"
 
-git commit --no-gpg-sign --allow-empty -m "Empty commit 1"
+git commit --allow-empty -m "Empty commit 1"
 git tag tag1
 
-git commit --no-gpg-sign --allow-empty -m "Empty commit 2"
+git commit --allow-empty -m "Empty commit 2"


### PR DESCRIPTION
removed the `--no-gpg-sign` from PR #141 and overrites the HOME variable to
force git using an empty config.

see changes in:
 * tests/repos/scripts/dont-render
 * tests/repos/scripts/no-newline-at-end-of-file
 * tests/repos/scripts/test_repo

I'll hope it helps!

cheers