### PR TITLE
add an API to disable highlighting by file name

### DIFF
--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -15,13 +15,15 @@ class Klaus(flask.Flask):
         'undefined': jinja2.StrictUndefined
     }
 
-    def __init__(self, repo_paths, site_name, use_smarthttp, ctags_policy='none'):
+    def __init__(self, repo_paths, site_name, use_smarthttp, ctags_policy='none',
+                 highlight_enabled=lambda f: True):
         """(See `make_app` for parameter descriptions.)"""
         repo_objs = [FancyRepo(path) for path in repo_paths]
         self.repos = dict((repo.name, repo) for repo in repo_objs)
         self.site_name = site_name
         self.use_smarthttp = use_smarthttp
         self.ctags_policy = ctags_policy
+        self.highlight_enabled = highlight_enabled
 
         flask.Flask.__init__(self, __name__)
 
@@ -83,7 +85,7 @@ class Klaus(flask.Flask):
 
 def make_app(repo_paths, site_name, use_smarthttp=False, htdigest_file=None,
              require_browser_auth=False, disable_push=False, unauthenticated_push=False,
-             ctags_policy='none'):
+             ctags_policy='none', highlight_enabled=lambda f: True):
     """
     Returns a WSGI app with all the features (smarthttp, authentication)
     already patched in.
@@ -106,6 +108,8 @@ def make_app(repo_paths, site_name, use_smarthttp=False, htdigest_file=None,
         - 'tags-and-branches': use ctags for revisions that are the HEAD of
           a tag or branc
         - 'ALL': use ctags for all revisions, may result in high server load!
+    :param highlight_enabled: a function that takes a filename and returns
+        false if the file should not be rendered or syntax-highlighted.
     """
     if unauthenticated_push:
         if not use_smarthttp:
@@ -122,6 +126,7 @@ def make_app(repo_paths, site_name, use_smarthttp=False, htdigest_file=None,
         site_name,
         use_smarthttp,
         ctags_policy,
+        highlight_enabled,
     )
     app.wsgi_app = utils.ProxyFix(app.wsgi_app)
 

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -283,6 +283,7 @@ class IndexView(TreeViewMixin, BaseRepoView):
                 'rendered_code': highlight_or_render(
                     force_unicode(readme_data),
                     force_unicode(readme_filename),
+                    highlight_enabled=current_app.highlight_enabled,
                 ),
             })
 
@@ -364,6 +365,7 @@ class BaseFileView(TreeViewMixin, BaseBlobView):
             force_unicode(self.context['blob_or_tree'].data),
             self.context['filename'],
             render_markup,
+            highlight_enabled=current_app.highlight_enabled,
             **ctags_args
         )
 


### PR DESCRIPTION
This adds an API that a uWSGI script can use to enable/disable highlighting on a per-file basis. I wanted this for my site because I don't like the syntax highlighting that Pygments uses for .txt files and README files, but it seems like it could be a generally-useful API.

I'm not a huge fan of the name of the `highlight_enabled` parameter, but I couldn't think of a better one. Happy to rename it if you can think of one!