### PR TITLE
Recognize more Markdown file extensions for READMEs.

### DIFF
--- a/klaus/views.py
+++ b/klaus/views.py
@@ -27,7 +27,7 @@ from klaus.utils import parent_directory, subpaths, force_unicode, guess_is_bina
                         guess_is_image, replace_dupes, sanitize_branch_name, encode_for_git
 
 
-README_FILENAMES = [b'README', b'README.md', b'README.markdown', b'README.rst']
+README_FILENAMES = [b'README', b'README.md', b'README.mkdn', b'README.mdwn', b'README.markdown', b'README.rst']
 
 
 def repo_list():

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -27,7 +27,7 @@ from klaus.utils import parent_directory, subpaths, force_unicode, guess_is_bina
                         guess_is_image, replace_dupes, sanitize_branch_name, encode_for_git
 
 
-README_FILENAMES = [b'README', b'README.md', b'README.rst']
+README_FILENAMES = [b'README', b'README.md', b'README.markdown', b'README.rst']
 
 
 def repo_list():


### PR DESCRIPTION
May I propose this one-line change?

The Principled Justification: [elsewhere in the source code](https://github.com/jonashaag/klaus/blob/876ba7536a06c9040e0057ba4b29e0d3d4fb51d2/klaus/markup.py#L33), files with these extensions are treated as Markdown, so they should here too, for consistency.

The Pragmatic Argument: GitHub recognizes these files as READMEs written in Markdown, so klaus should too.