### PR TITLE
Don't mangle repository name when path contains ".git"

### DIFF
--- a/klaus/repo.py
+++ b/klaus/repo.py
@@ -1,5 +1,6 @@
 import os
 import io
+import re
 import stat
 import subprocess
 
@@ -24,7 +25,7 @@ class FancyRepo(dulwich.repo.Repo):
         2. /x/y/ -> /x/y
         3. /x/y -> y
         """
-        return self.path.replace(".git", "").rstrip(os.sep).split(os.sep)[-1]
+        return re.sub(r"\.git$", "", self.path.rstrip(os.sep).rsplit(os.sep, 1)[-1])
 
     def get_last_updated_at(self):
         """Get datetime of last commit to this repository."""


### PR DESCRIPTION
Before this commit, the path `/x/klaus.github.io.git` would return `klaushub.io` instead of `klaus.github.io`.

Thank you for building and maintaining this nice Git web interface. I found it through [this page](https://git.wiki.kernel.org/index.php/Interfaces,_frontends,_and_tools#Web_Interfaces) and sadly many of them are unmaintained...