### PR TITLE
Properly keep track of exception so it can be reraised in force_unicode.

### DIFF
--- a/klaus/utils.py
+++ b/klaus/utils.py
@@ -134,11 +134,12 @@ def force_unicode(s):
     if isinstance(s, six.text_type):
         return s
 
+    last_exc = None
     # Try some default encodings:
     try:
         return s.decode('utf-8')
     except UnicodeDecodeError as exc:
-        pass
+        last_exc = exc
     try:
         return s.decode(locale.getpreferredencoding())
     except UnicodeDecodeError:
@@ -150,7 +151,7 @@ def force_unicode(s):
         if encoding is not None:
             return s.decode(encoding)
 
-    raise exc  # Give up.
+    raise last_exc  # Give up.
 
 
 def extract_author_name(email):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from klaus import utils
+
+
+class ForceUnicodeTests(unittest.TestCase):
+
+    def test_ascii(self):
+        self.assertEqual(u'foo', utils.force_unicode(b'foo'))
+
+    def test_utf8(self):
+        self.assertEqual(u'f\xce', utils.force_unicode(b'f\xc3\x8e'))
+
+    def test_invalid(self):
+        with mock.patch.object(utils, 'chardet', None):
+            self.assertRaises(
+                UnicodeDecodeError, utils.force_unicode, b'f\xce')


### PR DESCRIPTION
Properly keep track of exception so it can be reraised in force_unicode.

Without this, the last line of force_unicode() fails because of an undefined
variable "exc" on Python 3.
