### PR TITLE
fix display of code blocks in index view

### DIFF
--- a/klaus/static/klaus.css
+++ b/klaus/static/klaus.css
@@ -174,13 +174,18 @@ a.commit { color: black !important; }
 }
 
 
-/* Blob, Blame, Diff View */
+/* Blob, Blame, Diff, Markup View */
 .line { display: block; }
 .linenos { background-color: #f9f9f9; text-align: right; }
 .linenos a { color: #888; }
 .linenos a:hover { text-decoration: none; }
 .highlight-line, .highlight-line .line { background-color: #fefed0; }
 .linenos a { padding: 0 6px 0 6px; }
+.markup pre {
+  padding: 10px 12px;
+  background-color: #f9f9f9;
+  border: 1px solid #e0e0e0;
+}
 
 
 /* Blob, Blame View */
@@ -197,11 +202,6 @@ a.commit { color: black !important; }
 .blobview img, .blobview .markup { border: 1px solid #e0e0e0; }
 .blobview .markup h1:first-child { margin-top: 8px; }
 .blobview .markup { padding: 0 10px; }
-.blobview .markup pre {
-  padding: 10px 12px;
-  background-color: #f9f9f9;
-  border: 1px solid #e0e0e0;
-}
 
 
 /* Blame View */

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -278,12 +278,11 @@ class IndexView(TreeViewMixin, BaseRepoView):
                 'rendered_code': None,
             })
         else:
+            readme_filename = force_unicode(readme_filename) 
+            readme_data = force_unicode(readme_data)
             self.context.update({
-                'is_markup': markup.can_render(force_unicode(readme_filename)),
-                'rendered_code': highlight_or_render(
-                    force_unicode(readme_data),
-                    force_unicode(readme_filename),
-                ),
+                'is_markup': markup.can_render(readme_filename),
+                'rendered_code': highlight_or_render(readme_data, readme_filename)
             })
 
 

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -274,12 +274,12 @@ class IndexView(TreeViewMixin, BaseRepoView):
             (readme_filename, readme_data) = self._get_readme()
         except KeyError:
             self.context.update({
-                'is_markup': None,
+                'is_markup': False,
                 'rendered_code': None,
             })
         else:
             self.context.update({
-                'is_markup': markup.can_render(readme_filename),
+                'is_markup': markup.can_render(force_unicode(readme_filename)),
                 'rendered_code': highlight_or_render(
                     force_unicode(readme_data),
                     force_unicode(readme_filename),

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -274,7 +274,7 @@ class IndexView(TreeViewMixin, BaseRepoView):
             (readme_filename, readme_data) = self._get_readme()
         except KeyError:
             self.context.update({
-                'is_markup': False,
+                'is_markup': None,
                 'rendered_code': None,
             })
         else:


### PR DESCRIPTION
If readme files contain markup, they weren't displayed correctly in the
index view (no padding, no grey box).

The fix contains two changes:
- Use `force_unicode` on the readme's filename
- use the CSS properties for both blobview and non-blobview