### PR TITLE
Try a bit harder to come up with sensible names for tarballs and prefixes in tarballs.

### DIFF
--- a/klaus/utils.py
+++ b/klaus/utils.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+import binascii
 import os
 import re
 import time
@@ -242,3 +243,22 @@ def sanitize_branch_name(name, chars='./', repl='-'):
 def escape_html(s):
     return s.replace(b'&', b'&amp;').replace(b'<', b'&lt;') \
             .replace(b'>', b'&gt;').replace(b'"', b'&quot;')
+
+
+def tarball_basename(repo_name, rev):
+    """Determine the name for a tarball."""
+    sanitized_rev = sanitize_branch_name(rev, chars='/')
+    # If the rev is a tag name that already starts with the
+    # repo name, skip it.
+    if sanitized_rev.startswith(repo_name + '-'):
+        return sanitized_rev
+    if sanitized_rev.startswith('v'):
+        return "%s-%s" % (repo_name, sanitized_rev[1:])
+    if len(sanitized_rev) == 40:
+        try:
+            binascii.unhexlify(sanitized_rev)
+        except binascii.Error:
+            pass
+        else:
+            return "%s@%s" % (repo_name, sanitized_rev)
+    return "%s-%s" % (repo_name, sanitized_rev)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,3 +19,17 @@ class ForceUnicodeTests(unittest.TestCase):
         with mock.patch.object(utils, 'chardet', None):
             self.assertRaises(
                 UnicodeDecodeError, utils.force_unicode, b'f\xce')
+
+
+class TarballBasenameTests(unittest.TestCase):
+
+    def test_examples(self):
+        examples = [
+            ('v0.1', 'klaus-0.1'),
+            ('klaus-0.1', 'klaus-0.1'),
+            ('0.1', 'klaus-0.1'),
+            ('b3e70e08344ca3f83cc7033ecdbefa90443d7d2e',
+                'klaus@b3e70e08344ca3f83cc7033ecdbefa90443d7d2e'),
+            ]
+        for (rev, basename) in examples:
+            self.assertEqual(utils.tarball_basename('klaus', rev), basename)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,7 @@ class TarballBasenameTests(unittest.TestCase):
             ('0.1', 'klaus-0.1'),
             ('b3e70e08344ca3f83cc7033ecdbefa90443d7d2e',
                 'klaus@b3e70e08344ca3f83cc7033ecdbefa90443d7d2e'),
+            ('vanilla', 'klaus-vanilla'),
             ]
         for (rev, basename) in examples:
             self.assertEqual(utils.tarball_basename('klaus', rev), basename)


### PR DESCRIPTION
Try a bit harder to come up with sensible names for tarballs and prefixes in tarballs.

For revisions without a tag associated, keep the current name, i.e.:

SHA => klaus@SHA

For tags, cope with common syntaxes for tags:

0.1 => klaus-0.1
v0.1 => klaus-0.1
klaus-0.1 => klaus-0.1
