### PR TITLE
Handling invalid git repository and hidden folder

### DIFF
--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -4,7 +4,7 @@ import httpauth
 import dulwich.web
 from dulwich.errors import NotGitRepository
 from klaus import views, utils
-from klaus.repo import FancyRepo
+from klaus.repo import FancyRepo, InvalidRepo
 
 
 KLAUS_VERSION = utils.guess_git_revision() or '1.4.0'
@@ -88,7 +88,7 @@ class Klaus(flask.Flask):
             try:
                 repo_objs.append(FancyRepo(path))
             except NotGitRepository:
-                invalid_repos.append(path)
+                invalid_repos.append(InvalidRepo(path))
         return repo_objs, invalid_repos
 
 

--- a/klaus/contrib/wsgi_autoreloading.py
+++ b/klaus/contrib/wsgi_autoreloading.py
@@ -37,7 +37,7 @@ def make_autoreloading_app(repos_root, *args, **kwargs):
             # Refresh inner application with new repo list
             print("Reloading repository list...")
             _.inner_app = make_app(
-                [os.path.join(repos_root, x) for x in os.listdir(repos_root)],
+                [os.path.join(repos_root, x) for x in os.listdir(repos_root) if x[0] != '.'],
                 *args, **kwargs
             )
             _.should_reload = False

--- a/klaus/repo.py
+++ b/klaus/repo.py
@@ -266,3 +266,17 @@ class FancyRepo(dulwich.repo.Repo):
         bytesio = io.BytesIO()
         dulwich.patch.write_tree_diff(bytesio, self.object_store, parent_tree, commit.tree)
         return bytesio.getvalue()
+
+class InvalidRepo:
+    """Represent an invalid repository and store pertinent data."""
+
+    def __init__(self, path):
+        self.path = path
+
+    @property
+    def name(self):
+        """Get repository or folder name from path."""
+        path = os.path.basename(self.path)
+        if path.endswith('.git'):
+            path = path[:-4]
+        return path

--- a/klaus/static/klaus.css
+++ b/klaus/static/klaus.css
@@ -124,6 +124,12 @@ footer a:hover { text-decoration: none; }
 .repolist li a:hover { text-decoration: none; }
 .repolist li a:hover .name { text-decoration: underline; }
 
+.invalid { color: red; }
+.invalid .reason {
+  color: #737373;
+  font-size: 60%;
+  margin-left: 1px;
+}
 
 /* Base styles for history and commit views */
 .commit {

--- a/klaus/templates/repo_list.html
+++ b/klaus/templates/repo_list.html
@@ -36,7 +36,7 @@
   {% endfor %}
 </ul>
 
-{% if invalid_repos is defined and invalid_repos|length>0 %}
+{% if invalid_repos|length>0 %}
 <ul class="repolist invalid">
   {% for name in invalid_repos %}
     <li>

--- a/klaus/templates/repo_list.html
+++ b/klaus/templates/repo_list.html
@@ -38,9 +38,9 @@
 
 {% if invalid_repos|length>0 %}
 <ul class="repolist invalid">
-  {% for name in invalid_repos %}
+  {% for repo in invalid_repos %}
     <li>
-        <div class=name>{{ name }}</div>
+        <div class=name>{{ repo.name }}</div>
         <div class=reason>
           Invalid git repository
         </div>

--- a/klaus/templates/repo_list.html
+++ b/klaus/templates/repo_list.html
@@ -36,4 +36,17 @@
   {% endfor %}
 </ul>
 
+{% if invalid_repos is defined and invalid_repos|length>0 %}
+<ul class="repolist invalid">
+  {% for name in invalid_repos %}
+    <li>
+        <div class=name>{{ name }}</div>
+        <div class=reason>
+          Invalid git repository
+        </div>
+    </li>
+  {% endfor %}
+</ul>
+{% endif%}
+
 {% endblock %}

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -37,7 +37,8 @@ def repo_list():
     else:
         sort_key = lambda repo: (-(repo.get_last_updated_at() or -1), repo.name)
     repos = sorted(current_app.repos.values(), key=sort_key)
-    return render_template('repo_list.html', repos=repos, base_href=None)
+    invalid_repos = sorted([os.path.basename(path) for path in current_app.invalid_repos])
+    return render_template('repo_list.html', repos=repos, invalid_repos=invalid_repos, base_href=None)
 
 
 

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -37,7 +37,7 @@ def repo_list():
     else:
         sort_key = lambda repo: (-(repo.get_last_updated_at() or -1), repo.name)
     repos = sorted(current_app.repos.values(), key=sort_key)
-    invalid_repos = sorted([os.path.basename(path) for path in current_app.invalid_repos])
+    invalid_repos = sorted(current_app.invalid_repos, key=lambda repo: repo.name)
     return render_template('repo_list.html', repos=repos, invalid_repos=invalid_repos, base_href=None)
 
 

--- a/tests/repos/scripts/hidden_folder
+++ b/tests/repos/scripts/hidden_folder
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+# Hide the directory
+cd ..
+mv hidden_folder .hidden_folder

--- a/tests/repos/scripts/invalid_repo
+++ b/tests/repos/scripts/invalid_repo
@@ -1,0 +1,2 @@
+# Create an invalid git repo e.g an empty folder
+

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -43,3 +43,9 @@ def test_regression_gh233_treeview_paths():
         response = requests.get(UNAUTH_TEST_REPO_URL + "tree/HEAD/folder").text
         assert "blob/HEAD/test.txt" not in response
         assert "blob/HEAD/folder/test.txt" in response
+
+def test_display_invalid_repos():
+    with serve():
+        response = requests.get(TEST_SERVER).text
+        assert '<ul class="repolist invalid">' in response
+        assert '<div class=name>invalid_repo</div>' in response

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,7 @@ HTDIGEST_FILE = "tests/credentials.htdigest"
 TEST_REPO = os.path.abspath("tests/repos/build/test_repo")
 TEST_REPO_ROOT = os.path.abspath("tests/repos/build")
 TEST_REPO_URL = "test_repo/"
+TEST_SERVER = "http://localhost:9876/"
 UNAUTH_TEST_SERVER = "http://invalid:password@localhost:9876/"
 UNAUTH_TEST_REPO_URL = UNAUTH_TEST_SERVER + TEST_REPO_URL
 AUTH_TEST_SERVER = "http://testuser:testpassword@localhost:9876/"
@@ -23,7 +24,9 @@ TEST_REPO_NO_NEWLINE_URL = UNAUTH_TEST_SERVER + "no-newline-at-end-of-file/"
 TEST_REPO_DONT_RENDER = os.path.abspath("tests/repos/build/dont-render")
 TEST_REPO_DONT_RENDER_URL = UNAUTH_TEST_SERVER + "dont-render/"
 
-ALL_TEST_REPOS = [TEST_REPO, TEST_REPO_NO_NEWLINE, TEST_REPO_DONT_RENDER]
+TEST_INVALID_REPO = os.path.abspath("tests/repos/build/invalid_repo")
+
+ALL_TEST_REPOS = [TEST_REPO, TEST_REPO_NO_NEWLINE, TEST_REPO_DONT_RENDER, TEST_INVALID_REPO]
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This avoid getting an error 500 on an invalid git repository, as discussed in #176 and #231.

- the autoreloading app ignores hidden folders in `KLAUS_REPOS_ROOT`

- invalid repository are displayed in red in the repos list alongside an error message, instead of triggering an error 500.

The index page with invalid repos look like this:
![2019-06-11-185356_530x466_scrot](https://user-images.githubusercontent.com/15261469/59389116-89714700-8d3b-11e9-82b2-c1004007f962.png)


I am terrible at designing things, so advice to improve the display of invalid repositories are welcome!
