### PR TITLE
Use an older version of Dulwich on Python 2

### DIFF
--- a/klaus/repo.py
+++ b/klaus/repo.py
@@ -142,8 +142,8 @@ class FancyRepo(dulwich.repo.Repo):
 
     def get_tag_and_branch_shas(self):
         """Return a list of SHAs of all tags and branches."""
-        tag_shas = self.get_refs_as_dict('refs/tags/').values()
-        branch_shas = self.get_refs_as_dict('refs/heads/').values()
+        tag_shas = self.get_refs_as_dict(b'refs/tags/').values()
+        branch_shas = self.get_refs_as_dict(b'refs/heads/').values()
         return set(tag_shas) | set(branch_shas)
 
     def history(self, commit, path=None, max_commits=None, skip=0):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def install_data_files_hack():
 
 install_data_files_hack()
 
-requires = ['six', 'flask', 'Werkzeug>=0.15.0', 'pygments', 'dulwich>=0.19.3', 'httpauth', 'humanize']
+requires = ['six', 'flask', 'Werkzeug>=0.15.0', 'pygments', 'httpauth', 'humanize', 'dulwich>=0.19.3;python_version>="3.5"', 'dulwich>=0.19.3,<0.20;python_version<"3.5"']
 
 setup(
     name='klaus',

--- a/tests/test_manpage.py
+++ b/tests/test_manpage.py
@@ -13,7 +13,7 @@ def test_covers_all_cli_options():
     manpage = force_unicode(subprocess.check_output(["man", "./klaus.1"]))
 
     def assert_in_manpage(s):
-        clean = lambda x: re.sub('(.\\x08)|\s', '', x)
+        clean = lambda x: re.sub('(.\\x08)|\\s', '', x)
         assert clean(s) in clean(manpage), "%r not found in manpage" % s
 
     mock_parser = mock.Mock()


### PR DESCRIPTION
Use an older version of Dulwich on Python 2.x.

Fixes #252
