### PR TITLE
fix 'pip3' missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositor
     apk add --no-cache uwsgi-python git ctags  py3-six py3-markupsafe py3-pygments \
                        py3-dulwich py3-humanize py3-flask py3-flask-markdown py3-docutils
 
-RUN apk add --no-cache python3-dev gcc musl-dev && \
+RUN apk add --no-cache python3-dev py3-pip gcc musl-dev && \
     pip3 install python-ctags3 && \
     apk del python3-dev gcc musl-dev
 


### PR DESCRIPTION
Package 'pip3' is not found during the docker image build.
Fixed by 'py3-pip'.