### PR TITLE
added power support arch on yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,12 @@ jobs:
           tags: true
         provider: script
         script: ./build-and-push-docker.sh
+        # added power support arch.
+    - stage: deploy
+      script: skip
+      arch: ppc64le
+      deploy:
+        on:
+          tags: true
+        provider: script
+        script: ./build-and-push-docker.sh


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

