### PR TITLE
add 'hide-invalid-repositories' option

### DIFF
--- a/bin/klaus
+++ b/bin/klaus
@@ -63,6 +63,13 @@ def make_parser():
         type=git_repository,
     )
 
+    parser.add_argument(
+        "--hide-invalid-repos",
+        help="hide invalid repositories",
+        default=False,
+        action="store_true",
+    )
+
     grp = parser.add_argument_group("Git Smart HTTP")
     grp.add_argument(
         "--smarthttp", help="enable Git Smart HTTP serving", action="store_true"
@@ -121,6 +128,7 @@ def main():
 
     app = make_app(
         args.repos,
+        args.hide_invalid_repos,
         force_unicode(args.site_name or args.host),
         args.smarthttp,
         args.htdigest,

--- a/klaus.1
+++ b/klaus.1
@@ -29,6 +29,9 @@ site name showed in header. default: your hostname
 \fB\-\-version\fR
 print version number
 .TP
+\fB\-\-hide\-invalid\-repos\fR
+hide invalid repositories
+.TP
 \fB\-b\fR, \fB\-\-browser\fR
 open klaus in a browser on server start
 .TP

--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -16,7 +16,14 @@ class Klaus(flask.Flask):
         "undefined": jinja2.StrictUndefined,
     }
 
-    def __init__(self, repo_paths, site_name, use_smarthttp, ctags_policy="none"):
+    def __init__(
+        self,
+        repo_paths,
+        hide_invalid_repos,
+        site_name,
+        use_smarthttp,
+        ctags_policy="none",
+    ):
         """(See `make_app` for parameter descriptions.)"""
         self.site_name = site_name
         self.use_smarthttp = use_smarthttp
@@ -24,7 +31,10 @@ class Klaus(flask.Flask):
 
         valid_repos, invalid_repos = self.load_repos(repo_paths)
         self.valid_repos = {repo.namespaced_name: repo for repo in valid_repos}
-        self.invalid_repos = {repo.namespaced_name: repo for repo in invalid_repos}
+        if hide_invalid_repos:
+            self.invalid_repos = {}
+        else:
+            self.invalid_repos = {repo.namespaced_name: repo for repo in invalid_repos}
 
         flask.Flask.__init__(self, __name__)
 
@@ -102,6 +112,7 @@ class Klaus(flask.Flask):
 
 def make_app(
     repo_paths,
+    hide_invalid_repos,
     site_name,
     use_smarthttp=False,
     htdigest_file=None,
@@ -121,6 +132,7 @@ def make_app(
                 ...
                 None: [list of paths of repositories without namespace]
             }
+    :param hide_invalid_repos: Hide invalid repositories
     :param site_name: Name of the Web site (e.g. "John Doe's Git Repositories")
     :param use_smarthttp: Enable Git Smart HTTP mode, which makes it possible to
         pull from the served repositories. If `htdigest_file` is set as well,
@@ -158,6 +170,7 @@ def make_app(
 
     app = Klaus(
         repo_paths,
+        hide_invalid_repos,
         site_name,
         use_smarthttp,
         ctags_policy,

--- a/klaus/contrib/app_args.py
+++ b/klaus/contrib/app_args.py
@@ -8,6 +8,9 @@ def get_args_from_env():
         repos = repos.split()
     args = (repos, os.environ.get("KLAUS_SITE_NAME", "unnamed site"))
     kwargs = dict(
+        hide_invalid_repositories=os.environ.get(
+            "KLAUS_HIDE_INVALID_REPOSITORIES", "0"
+        ),
         htdigest_file=os.environ.get("KLAUS_HTDIGEST_FILE"),
         use_smarthttp=strtobool(os.environ.get("KLAUS_USE_SMARTHTTP", "0")),
         require_browser_auth=strtobool(


### PR DESCRIPTION
Hey.
As I don't mind if Klaus find some invalid repositories, I added an option to hide those.

During the app building, when it formats the {in,}valid repositories, it checks for this newly created option and dismiss the invalid ones.

I hope that's enough for you!
Thanks for this super software :)