### PR TITLE
Really basic implementation of a metrics target for use by prometheus

### DIFF
--- a/klaus/__init__.py
+++ b/klaus/__init__.py
@@ -60,7 +60,6 @@ class Klaus(flask.Flask):
         # fmt: off
         for endpoint, rule in [
             ('repo_list',   '/'),
-            ('robots_txt',  '/robots.txt/'),
             ('blob',        '/<repo>/blob/'),
             ('blob',        '/<repo>/blob/<rev>/<path:path>'),
             ('blame',       '/<repo>/blame/'),
@@ -77,6 +76,8 @@ class Klaus(flask.Flask):
             ('history',     '/<repo>/tree/<rev>/'),
             ('history',     '/<repo>/tree/<rev>/<path:path>'),
             ('download',    '/<repo>/tarball/<path:rev>/'),
+            ('robots_txt',  '/robots.txt'),
+            ('metrics',     '/metrics'),
         ]:
             self.add_url_rule(rule, view_func=getattr(views, endpoint))
             if "<repo>" in rule:

--- a/klaus/views.py
+++ b/klaus/views.py
@@ -13,6 +13,14 @@ from werkzeug.exceptions import NotFound
 from werkzeug.wrappers import Response
 
 try:
+    from prometheus_client import (
+        generate_latest as generate_latest_metrics,
+        CONTENT_TYPE_LATEST as METRICS_CONTENT_TYPE,
+        )
+except ImportError:
+    generate_latest_metrics = None
+
+try:
     import ctags
 except ImportError:
     ctags = None
@@ -81,6 +89,12 @@ def repo_list():
         search_query=search_query,
         base_href=None,
     )
+
+
+def metrics():
+    if generate_latest_metrics is None:
+        return Response("prometheus-client not installed", 404)
+    return Response(generate_latest_metrics(), mimetype=METRICS_CONTENT_TYPE)
 
 
 def robots_txt():


### PR DESCRIPTION
Really basic implementation of a metrics target for use by prometheus.

Some caveats:

 * this exposes /metrics on the same port as the rest of klaus;
   one might not want to expose internal metrics there
 * this doesn't yet add any really useful metrics
   (number of requests, failures, exceptions, etc). At the moment
   it just exports a bunch of python statstics.
