### PR TITLE
Add KLAUS_URL build argument to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ RUN apk add --no-cache python3-dev py3-pip gcc musl-dev && \
     apk del python3-dev gcc musl-dev
 
 ARG KLAUS_VERSION
-RUN pip3 install klaus${KLAUS_VERSION:+==}${KLAUS_VERSION}
+ARG KLAUS_URL=klaus${KLAUS_VERSION:+==}${KLAUS_VERSION}
+RUN pip3 install ${KLAUS_URL}


### PR DESCRIPTION
This allows building forks etc by specifying e.g. a git+http:// URL.
If the argument is not specified, KLAUS_VERSION behaves as before.