### PR TITLE
Fall back to just converting unknown bytestings using latin1, replacing invalid characters

### DIFF
--- a/klaus/utils.py
+++ b/klaus/utils.py
@@ -144,7 +144,8 @@ def force_unicode(s):
     try:
         return s.decode("utf-8")
     except UnicodeDecodeError as exc:
-        last_exc = exc
+        pass
+
     try:
         return s.decode(locale.getpreferredencoding())
     except UnicodeDecodeError:
@@ -156,7 +157,7 @@ def force_unicode(s):
         if encoding is not None:
             return s.decode(encoding)
 
-    raise last_exc  # Give up.
+    return s.decode('latin1', 'replace')
 
 
 def extract_author_name(email):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,7 @@ class ForceUnicodeTests(unittest.TestCase):
         if sys.platform.startswith("win"):
             return
         with mock.patch.object(utils, "chardet", None):
-            self.assertRaises(UnicodeDecodeError, utils.force_unicode, b"f\xce")
+            self.assertEqual('fÎ', utils.force_unicode(b"f\xce"))
 
 
 class TarballBasenameTests(unittest.TestCase):


### PR DESCRIPTION
Fall back to just converting unknown bytestings using latin1, replacing invalid characters.

This at least allows rendering pages rather than throwing 500s.
