### PR TITLE
Support viewing blame of empty files

### DIFF
--- a/klaus/repo.py
+++ b/klaus/repo.py
@@ -215,7 +215,7 @@ class FancyRepo(dulwich.repo.Repo):
         # XXX see comment in `.history()`
         cmd = ["git", "blame", "-ls", "--root", decode_from_git(commit.id), "--", path]
         output = subprocess.check_output(cmd, cwd=os.path.abspath(self.path))
-        sha1_sums = [line[:40] for line in output.strip().split(b"\n")]
+        sha1_sums = [line[:40] for line in output.strip().split(b"\n") if line]
         return [
             None if self[sha1] is None else decode_from_git(self[sha1].id)
             for sha1 in sha1_sums

--- a/runtests.sh
+++ b/runtests.sh
@@ -14,5 +14,3 @@ if [ $# -eq 0 ]; then
 else
   pytest "$@"
 fi
-
-

--- a/runtests.sh
+++ b/runtests.sh
@@ -8,9 +8,11 @@
   done
 )
 
-export PYTHONPATH=tests
+export PYTHONPATH=tests:${PYTHONPATH}
 if [ $# -eq 0 ]; then
   pytest -v tests
 else
   pytest "$@"
 fi
+
+

--- a/tests/repos/scripts/test_repo
+++ b/tests/repos/scripts/test_repo
@@ -10,8 +10,10 @@ echo "int a;" > test.c
 echo "function test() {}" > test.js
 mkdir -p folder
 echo > folder/test.txt
+touch empty.txt
 git add test.c
 git add test.js
+git add empty.txt
 git add folder
 git commit -m "Add some code"
 

--- a/tests/test_blame.py
+++ b/tests/test_blame.py
@@ -8,6 +8,12 @@ def test_blame():
         assert response.status_code == 200
 
 
+def test_blame_empty():
+    with serve():
+        response = requests.get(UNAUTH_TEST_REPO_URL + "blame/HEAD/empty.txt")
+        assert response.status_code == 200
+
+
 def test_dont_show_blame_link():
     with serve():
         for file in ["binary", "image.jpg", "toolarge"]:

--- a/tests/test_blame.py
+++ b/tests/test_blame.py
@@ -4,7 +4,7 @@ from .utils import *
 
 def test_blame():
     with serve():
-        response = requests.get(UNAUTH_TEST_REPO_URL + "blob/HEAD/test.c")
+        response = requests.get(UNAUTH_TEST_REPO_URL + "blame/HEAD/test.c")
         assert response.status_code == 200
 
 


### PR DESCRIPTION
Support viewing blame of empty files.

Without this, klaus tries to access repo[b''] which leads to a KeyError.
