### PR TITLE
Fix 500 error when accessing history of blob objects

### DIFF
--- a/klaus/views.py
+++ b/klaus/views.py
@@ -231,6 +231,9 @@ class ReadmeMixin(object):
         commit, path = self.context["commit"], self.context["path"]
         tree = self.context["repo"].get_blob_or_tree(commit, path)
 
+        if not isinstance(tree, dulwich.objects.Tree):
+            raise KeyError
+
         for name in README_FILENAMES:
             if name.lower() in [t.lower() for t in tree]:
                 obj = self.context["repo"][tree[name][1]]


### PR DESCRIPTION
Fix 500 error when accessing history of blob objects.

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python3/dist-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python3/dist-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python3/dist-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/usr/lib/python3/dist-packages/flask/views.py", line 84, in view
    return current_app.ensure_sync(self.dispatch_request)(*args, **kwargs)
  File "/home/jelmer/src/klaus/klaus/views.py", line 167, in dispatch_request
    self.make_template_context(repo, namespace, rev, path.strip("/"))
  File "/home/jelmer/src/klaus/klaus/views.py", line 308, in make_template_context
    self.context.update(self.get_readme_context())
  File "/home/jelmer/src/klaus/klaus/views.py", line 246, in get_readme_context
    (readme_filename, readme_data) = self._get_readme()
  File "/home/jelmer/src/klaus/klaus/views.py", line 235, in _get_readme
    if name.lower() in [t.lower() for t in tree]:
TypeError: 'Blob' object is not iterable
