### PR TITLE
Replace invalid characters even when chardet has found an encoding

### DIFF
--- a/klaus/utils.py
+++ b/klaus/utils.py
@@ -159,7 +159,7 @@ def force_unicode(s):
         # Try chardet, if available
         encoding = chardet.detect(s)["encoding"]
         if encoding is not None:
-            return s.decode(encoding)
+            return s.decode(encoding, 'replace')
 
     return s.decode('latin1', 'replace')
 


### PR DESCRIPTION
Replace invalid characters even when chardet has found an encoding

In some cases, it seems to find an encoding that's not valid for the entire string.
