### PR TITLE
get_default_branch: Use HEAD instead of guessing

### DIFF
--- a/klaus/repo.py
+++ b/klaus/repo.py
@@ -137,20 +137,13 @@ class FancyRepo(dulwich.repo.Repo):
         raise KeyError(rev)
 
     def get_default_branch(self):
-        """Tries to guess the default repo branch name."""
-        for candidate in ["master", "main", "trunk", "default", "gh-pages"]:
-            try:
-                self.get_commit(candidate)
-                return candidate
-            except InaccessibleRef:
-                pass
-        for name in self.get_branch_names():
-            try:
-                self.get_commit(name)
-                return name
-            except InaccessibleRef:
-                pass
-        else:
+        """Retrieves the default branch name from HEAD"""
+        try:
+            self.head()
+            for branch in self.get_branch_names():
+                if self.get_commit(branch) == self.get_commit(self.head().decode()):
+                    return branch
+        except InaccessibleRef:
             return None
 
     def get_ref_names_ordered_by_last_commit(self, prefix, exclude=None):


### PR DESCRIPTION
Fixes #307 