### PR TITLE
Handle chardet returning encodings unknown by Python

### DIFF
--- a/klaus/utils.py
+++ b/klaus/utils.py
@@ -159,7 +159,10 @@ def force_unicode(s):
         # Try chardet, if available
         encoding = chardet.detect(s)["encoding"]
         if encoding is not None:
-            return s.decode(encoding, 'replace')
+            try:
+                return s.decode(encoding, 'replace')
+            except LookupError:
+                pass
 
     return s.decode('latin1', 'replace')
 


### PR DESCRIPTION
An example of this is e.g. EUC-TW