### PR TITLE
Fix docker build error of externally-managed-environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositor
                        py3-dulwich py3-humanize py3-flask py3-flask-markdown py3-docutils
 
 RUN apk add --no-cache python3-dev py3-pip gcc musl-dev && \
-    pip3 install python-ctags3 && \
+    pip3 install --break-system-packages python-ctags3 && \
     apk del python3-dev gcc musl-dev
 
 COPY . /klaus
-RUN pip3 install /klaus && rm -rf /klaus
+RUN pip3 install --break-system-packages /klaus && rm -rf /klaus
 
 # https://github.com/jonashaag/klaus/issues/300
 RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
I tried to build the docker container, it refused to install the pip packages throwing `error: externally-managed-environment`

I think as long this is used inside a docker container it is okay to use the `--break-system-packages` option of pip. 
Otherwise according to a note while trying to install with pip a venv is recommended.