### PR TITLE
Support fully using dulwich

### DIFF
--- a/klaus/ctagsutils.py
+++ b/klaus/ctagsutils.py
@@ -3,6 +3,9 @@ import shutil
 import subprocess
 import tempfile
 
+from dulwich import porcelain
+from dulwich.repo import Repo
+
 
 def check_have_compatible_ctags():
     """Check that the 'ctags' binary is a compatible ctags (Universal or Exuberant, not etags etc)"""
@@ -21,17 +24,20 @@ def create_tagsfile(git_repo_path, git_rev):
 
     :return: path to the generated tagsfile
     """
-    assert (
-        check_have_compatible_ctags()
-    ), "'ctags' binary is missing or not *Universal* (or *Exuberant*) ctags"
+    assert check_have_compatible_ctags(), (
+        "'ctags' binary is missing or not *Universal* (or *Exuberant*) ctags"
+    )
 
     _, target_tagsfile = tempfile.mkstemp()
     checkout_tmpdir = tempfile.mkdtemp()
     try:
-        subprocess.check_call(
-            ["git", "clone", "-q", "--shared", git_repo_path, checkout_tmpdir]
-        )
-        subprocess.check_call(["git", "checkout", "-q", git_rev], cwd=checkout_tmpdir)
+        # Clone the repository using dulwich
+        porcelain.clone(git_repo_path, checkout_tmpdir, checkout=False)
+
+        # Checkout the specific revision
+        repo = Repo(checkout_tmpdir)
+        repo.reset_index(repo[git_rev.encode()].tree)
+
         subprocess.check_call(
             ["ctags", "--fields=+l", "-Rno", target_tagsfile], cwd=checkout_tmpdir
         )

--- a/klaus/repo.py
+++ b/klaus/repo.py
@@ -22,6 +22,10 @@ from klaus.utils import (
 )
 
 InaccessibleRef = (SymrefLoop, KeyError)  # type: ignore
+# Switch between subprocess and dulwich implementations
+# Set to True to use pure-Python dulwich, False to use git subprocess
+FULL_DULWICH = False
+
 NOT_SET = "__not_set__"
 
 
@@ -229,39 +233,82 @@ class FancyRepo:
 
         Similar to `git log [branch/commit] [--skip skip] [-n max_commits]`.
         """
-        # XXX The pure-Python/dulwich code is very slow compared to `git log`
-        #     at the time of this writing (mid-2012).
-        #     For instance, `git log .tx` in the Django root directory takes
-        #     about 0.15s on my machine whereas the history() method needs 5s.
-        #     Therefore we use `git log` here until dulwich gets faster.
-        #     For the pure-Python implementation, see the 'purepy-hist' branch.
+        if FULL_DULWICH:
+            # Pure-Python dulwich implementation
+            walker = self.dulwich_repo.get_walker(
+                include=[commit.id], paths=[encode_for_git(path)] if path else None
+            )
 
-        cmd = ["git", "log", "--format=%H"]
-        if skip:
-            cmd.append("--skip=%d" % skip)
-        if max_commits:
-            cmd.append("--max-count=%d" % max_commits)
-        cmd.append(decode_from_git(commit.id))
-        if path:
-            cmd.extend(["--", path])
+            # Skip the first 'skip' commits
+            for _ in range(skip):
+                try:
+                    next(walker)
+                except StopIteration:
+                    return []
 
-        output = subprocess.check_output(cmd, cwd=os.path.abspath(self.path))
-        sha1_sums = output.strip().split(b"\n")
-        return [self[sha1] for sha1 in sha1_sums]
+            # Collect up to max_commits
+            commits = []
+            for entry in walker:
+                commits.append(self[entry.commit.id])
+                if max_commits and len(commits) >= max_commits:
+                    break
+
+            return commits
+        else:
+            # XXX The pure-Python/dulwich code is very slow compared to `git log`
+            #     at the time of this writing (mid-2012).
+            #     For instance, `git log .tx` in the Django root directory takes
+            #     about 0.15s on my machine whereas the history() method needs 5s.
+            #     Therefore we use `git log` here until dulwich gets faster.
+            #     For the pure-Python implementation, see the 'purepy-hist' branch.
+
+            cmd = ["git", "log", "--format=%H"]
+            if skip:
+                cmd.append("--skip=%d" % skip)
+            if max_commits:
+                cmd.append("--max-count=%d" % max_commits)
+            cmd.append(decode_from_git(commit.id))
+            if path:
+                cmd.extend(["--", path])
+
+            output = subprocess.check_output(cmd, cwd=os.path.abspath(self.path))
+            sha1_sums = output.strip().split(b"\n")
+            return [self[sha1] for sha1 in sha1_sums]
 
     @synchronized
     def blame(self, commit, path):
         """Return a 'git blame' list for the file at `path`: For each line in
         the file, the list contains the commit that last changed that line.
         """
-        # XXX see comment in `.history()`
-        cmd = ["git", "blame", "-ls", "--root", decode_from_git(commit.id), "--", path]
-        output = subprocess.check_output(cmd, cwd=os.path.abspath(self.path))
-        sha1_sums = [line[:40] for line in output.strip().split(b"\n") if line]
-        return [
-            None if self[sha1] is None else decode_from_git(self[sha1].id)
-            for sha1 in sha1_sums
-        ]
+        if FULL_DULWICH:
+            from dulwich import porcelain
+
+            encoded_path = encode_for_git(path)
+            blame_entries = porcelain.blame(
+                self.dulwich_repo, encoded_path, committish=commit.id
+            )
+
+            return [
+                decode_from_git(line_commit.id)
+                for ((line_commit, _tree_entry), _line) in blame_entries
+            ]
+        else:
+            # XXX see comment in `.history()`
+            cmd = [
+                "git",
+                "blame",
+                "-ls",
+                "--root",
+                decode_from_git(commit.id),
+                "--",
+                path,
+            ]
+            output = subprocess.check_output(cmd, cwd=os.path.abspath(self.path))
+            sha1_sums = [line[:40] for line in output.strip().split(b"\n") if line]
+            return [
+                None if self[sha1] is None else decode_from_git(self[sha1].id)
+                for sha1 in sha1_sums
+            ]
 
     @synchronized
     def get_blob_or_tree(self, commit, path):

--- a/klaus/utils.py
+++ b/klaus/utils.py
@@ -4,7 +4,6 @@ import locale
 import mimetypes
 import os
 import re
-import subprocess
 import time
 import warnings
 from typing import Union
@@ -14,6 +13,7 @@ try:
 except ImportError:
     chardet = None  # type: ignore
 
+from dulwich.repo import Repo
 from humanize import naturaltime
 from werkzeug.middleware.proxy_fix import ProxyFix as WerkzeugProxyFix
 
@@ -238,14 +238,15 @@ def guess_git_revision():
     """
     git_dir = os.path.join(os.path.dirname(__file__), "..", ".git")
     try:
-        return force_unicode(
-            subprocess.check_output(
-                ["git", "log", "--format=%h", "-n", "1"], cwd=git_dir
-            ).strip()
-        )
-    except OSError:
-        # Either the git executable couldn't be found in the OS's PATH
-        # or no ".git" directory exists, i.e. this is no "bleeding-edge" installation.
+        if os.path.exists(git_dir):
+            repo = Repo(os.path.dirname(git_dir))
+            commit = repo[repo.head()]
+            return force_unicode(commit.id.decode()[:7])
+        else:
+            return None
+    except (OSError, KeyError):
+        # Either no ".git" directory exists, or we couldn't read it
+        # i.e. this is no "bleeding-edge" installation.
         return None
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requires = [
     "pygments",
     "httpauth>=0.4",
     "humanize",
-    "dulwich>=0.19.3",
+    "dulwich>=1",
 ]
 
 setup(

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -1,9 +1,9 @@
 import os
-import subprocess
 from importlib import reload  # Python 3.4+
 
 import pytest
 import requests
+from dulwich import porcelain
 
 from klaus.contrib import app_args
 
@@ -132,10 +132,18 @@ def _can_push(http_get, url):
             _check_http200(
                 http_get, TEST_REPO_NO_NAMESPACE_BASE_URL + "git-receive-pack"
             ),
-            subprocess.call(["git", "push", url, "master"], cwd=TEST_REPO_NO_NAMESPACE)
-            == 0,
+            _dulwich_push(url, TEST_REPO_NO_NAMESPACE),
         ]
     )
+
+
+def _dulwich_push(url, repo_path):
+    """Push master branch to a remote URL using dulwich."""
+    try:
+        porcelain.push(repo_path, url, "master")
+        return True
+    except porcelain.Error:
+        return False
 
 
 def _GET_unauth(url=""):

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -4,6 +4,8 @@ from importlib import reload  # Python 3.4+
 import pytest
 import requests
 from dulwich import porcelain
+from dulwich.client import HTTPUnauthorized
+from dulwich.errors import NotGitRepository
 
 from klaus.contrib import app_args
 
@@ -142,7 +144,7 @@ def _dulwich_push(url, repo_path):
     try:
         porcelain.push(repo_path, url, "master")
         return True
-    except porcelain.Error:
+    except (porcelain.Error, NotGitRepository, HTTPUnauthorized):
         return False
 
 


### PR DESCRIPTION
Implement dulwich alternatives for git log and git blame operations in
repo.py. The FULL_DULWICH flag (default False) allows switching between
pure-Python dulwich implementation and git subprocess calls. This gives
users the option to use the faster subprocess approach if needed while
defaulting to the pure-Python implementation.

- Replace history() method's git log with dulwich's get_walker
- Replace blame() method's git blame with dulwich.porcelain.blame
- Keep subprocess implementations available when FULL_DULWICH=False